### PR TITLE
chore: set renovate pr creation to "not-pending"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "pinVersions": true,
   "semanticCommits": true,
+  "prCreation": "not-pending",
   "depTypes": [{"depType": "dependencies", "pinVersions": false}]
 }


### PR DESCRIPTION
Renovate recently added a custom "status check" for all its branches - "unpublish-safe". Details here: https://github.com/singapore/renovate/blob/master/docs/status-checks.md#unpublish-safe
In short: because npm package authors can unpublish versions of their package within first 24 hours after release, we don't recommend updating to those unless such an update is critical.
However, it may also seem annoying that Renovate raises PRs but with status "pending" (it changes to "success" 24 hours after package was released). To eliminate such annoyance, you can set the config option "prCreation" to "not-pending" as in this PR. That way, new versions are detected and branches created for testing, but the PR is not created until either all tests are "success" or one or more of them have failed.

<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
- [ ] Add your name and email to the AUTHORS file (optional)
- [ ] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
