### PR TITLE
Zen observable undefined

### DIFF
--- a/packages/zen-observable-ts/package.json
+++ b/packages/zen-observable-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zen-observable-ts",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "An Implementation of ES Observables in Typescript",
   "author": "Evans Hauser <evanshauser@gmail.com>",
   "contributors": [],

--- a/packages/zen-observable-ts/src/zenObservable.ts
+++ b/packages/zen-observable-ts/src/zenObservable.ts
@@ -29,9 +29,8 @@ function subscriptionClosed(subscription: Subscription) {
 }
 
 function closeSubscription(subscription: Subscription) {
-  if (subscriptionClosed(subscription)) {
-    return;
-  }
+  if (!subscription) return;
+  if (subscriptionClosed(subscription)) return;
 
   subscription._observer = undefined;
   cleanupSubscription(subscription);


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
@evanshauser @stubailo I was getting an error on the 2.0 when unsubscribing where `this` was undefined so the cleanup was throwing. I'm not sure if this is the correct fix, or if I'm doing something wrong AC 2.0 branch. I would love some feedback!