### PR TITLE
removed instanceof by simple duck typing for testing if provided link…

### DIFF
--- a/packages/apollo-link-core/src/linkUtils.ts
+++ b/packages/apollo-link-core/src/linkUtils.ts
@@ -5,13 +5,14 @@ import { ApolloLink, FunctionLink } from './link';
 import Observable from 'zen-observable-ts';
 
 export function validateLink(link: ApolloLink): ApolloLink {
-  if (link instanceof ApolloLink && typeof link.request === 'function') {
-    return link;
+  if (typeof link.split !== 'function' && typeof link.concat !== 'function') {
+    throw new LinkError('Link does not seem to be a ApolloLink object', link);
   } else {
-    throw new LinkError(
-      'Link does not extend ApolloLink and implement request',
-      link,
-    );
+    if (typeof link.request === 'function') {
+      return link;
+    } else {
+      throw new LinkError('Link does not implement request', link);
+    }
   }
 }
 


### PR DESCRIPTION
… is an ApolloLink

It solves the issue #76 by not using `instanceof` anymore and replacing it with simple duck typing test.
This PR is just here to get you the idea and doesn't brake any test but some contributors might want to add a new test case to avoid side effect that I'm not aware of.
