### PR TITLE
fix(docs): some tweaks to apollo-link-retry README

### DIFF
--- a/packages/apollo-link-retry/README.md
+++ b/packages/apollo-link-retry/README.md
@@ -1,7 +1,7 @@
 # Retry Link
 
 ## Purpose
-An Apollo Link to allow multiple attempts when an operation has failed. One such use case is to try a request while a network connection is offline and retry until it comes back online. Retry's can vary based on operation through the configuration of the link.
+An Apollo Link to allow multiple attempts when an operation has failed. One such use case is to try a request while a network connection is offline and retry until it comes back online. You can configure a RetryLink to vary the number of times it retries and how long it waits between retries through its configuration.
 
 ## Installation
 
@@ -15,20 +15,24 @@ const link = new RetryLink();
 ```
 
 ## Options
-Retry Link takes an object with three options on it to customize the behavoir of the link.
+Retry Link takes an object with three options on it to customize the behavior of the link.
 
-|name|value|default|required|
+Retry Link retries on network errors only, not on GraphQL errors.
+
+The default delay algorithm is to wait `delay` ms between each retry. You can customize the algorithm (eg, replacing with exponential backoff) with the `interval` option.
+
+|name|value|default|meaning|
 |---|---|---|---|
-|max|number or Operation => number|10|false|
-|delay|number or Operation => number|300|false|
-|interval|(delay: number, count: number) => number|delay => delay|false|
+|max|number or (Operation => number)|10|max number of times to try a single operation before giving up|
+|delay|number or (Operation => number)|300|input to the interval function below|
+|interval|(delay: number, count: number) => number|(delay, count => delay)|amount of time (in ms) to wait before the next attempt; count is the number of requests previously tried|
 ```js
-import RetryLink from "apollo-link-retry"
+import RetryLink from "apollo-link-retry";
 
-const max = (operation) => operation.getContext().max
+const max = (operation) => operation.getContext().max;
 const delay = 5000;
 const interval = (delay, count) => {
-  if (count > 5) return 10,000;
+  if (count > 5) return 10000;
   return delay;
 }
 
@@ -40,4 +44,4 @@ const link = new RetryLink({
 ```
 
 ## Context
-The Retry Link does not use the context for anything
+The Retry Link does not use the context for anything.


### PR DESCRIPTION
- Clarify that it only retries on network errors
- Describe the default delay/interval behavior in a paragraph
- Drop `required` column in options table --- existence of `default` for all of
  them should make that clear
- Parenthesize `number or (Operation => number)` for clarity
- Document what options mean in the table (including units)
- Fix syntax error in example
- Add trailing semicolons in example
- Grammar, spelling (avoid "Retry's", "behavoir", sentences with no terminal
  punctuation)



Note: if I were reviewing the original code I would strongly encourage adding
`MS` to the end of the `interval` and `delay` option names. Even though
milliseconds are very common in JS specifically, unitless parameters are much
more error-prone than parameters which specify their units.  It maybe be too
late to make this change without compatibility issues, though.