### PR TITLE
Fix broken Overview link

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -13,7 +13,7 @@ First, you'll need to install the `apollo-link` npm package.
 npm install apollo-link --save
 ```
 
-Apollo Link has two main exports, the `ApolloLink` interface and the `execute` function. The `ApolloLink` interface is used to create custom links, compose multiple links together, and can be extended to support more powerful use cases. The `execute` function is how to use a link and an operation to create a request. For a deeper dive on how to use links in your application, check out our Apollo Link [concepts guide](./overview.html).
+Apollo Link has two main exports, the `ApolloLink` interface and the `execute` function. The `ApolloLink` interface is used to create custom links, compose multiple links together, and can be extended to support more powerful use cases. The `execute` function is how to use a link and an operation to create a request. For a deeper dive on how to use links in your application, check out our Apollo Link [concepts guide](./overview.md).
 
 <h2 id="apollo-client">Usage</h2>
 


### PR DESCRIPTION
Was linking to `overview.html` instead of `overview.md`.