### PR TITLE
Fix typings for operationFnOrNumber

### DIFF
--- a/packages/apollo-link-retry/src/retryLink.ts
+++ b/packages/apollo-link-retry/src/retryLink.ts
@@ -11,7 +11,7 @@ const operationFnOrNumber = prop =>
 
 const defaultInterval = delay => delay;
 
-export type ParamFnOrNumber = (operation: Operation) => number | number;
+export type ParamFnOrNumber = ((operation: Operation) => number) | number;
 
 export class RetryLink extends ApolloLink {
   private delay: ParamFnOrNumber;


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
Tiny fix to make sure typings are as I think they were intended. The current `() => number | number` is interpreted by tsc as simply `() => number`

- [ ] Update CHANGELOG.md with your change

