### PR TITLE
changed fetcherOptions to fetchOptions to match API docs

### DIFF
--- a/packages/apollo-link-http/CHANGELOG.md
+++ b/packages/apollo-link-http/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change log
 
 ### vNEXT
+
+### v0.9.0
+- changed `fetcherOptions` to be `fetchOptions` and added a test for using 'GET' requests
+
+### v0.8.0
 - throw error on empty ExectionResult (missing)
 - support setting credentials, headers, and fetcherOptions in the setup of the link
 - removed sending of context to the server and allowed opt-in of sending extensions

--- a/packages/apollo-link-http/README.md
+++ b/packages/apollo-link-http/README.md
@@ -36,7 +36,7 @@ HTTP Link takes an object with some options on it to customize the behavior of t
 
 
 ## Context
-The HTTP Link uses the `headers` field on the context to allow passing headers to the HTTP request. It also supports the `credentials` field for defining credentials policy for fetch and `fetchOptions` to allow generic fetch overrides (i.e. method: "GET"). These options will override the same key if passed when creating the the link.
+The HTTP Link uses the `headers` field on the context to allow passing headers to the HTTP request. It also supports the `credentials` field for defining credentials policy for fetch and `fetcherOptions` to allow generic fetch overrides (i.e. method: "GET"). These options will override the same key if passed when creating the the link.
 
 |name|value|default|required|
 |---|---|---|---|

--- a/packages/apollo-link-http/src/__tests__/httpLink.ts
+++ b/packages/apollo-link-http/src/__tests__/httpLink.ts
@@ -31,6 +31,8 @@ describe('HttpLink', () => {
     fetchMock.post('begin:data', data);
     fetchMock.post('begin:error', mockError);
 
+    fetchMock.get('begin:data', data);
+
     const next = jest.fn();
     const error = jest.fn();
     const complete = jest.fn();
@@ -329,11 +331,11 @@ describe('HttpLink', () => {
       done();
     });
   });
-  it('adds fetcherOptions to the request from the setup', done => {
+  it('adds fetchOptions to the request from the setup', done => {
     const variables = { params: 'stub' };
     const link = createHttpLink({
       uri: 'data',
-      fetcherOptions: { signal: 'foo' },
+      fetchOptions: { signal: 'foo' },
     });
 
     execute(link, { query: sampleQuery, variables }).subscribe(result => {
@@ -342,11 +344,42 @@ describe('HttpLink', () => {
       done();
     });
   });
-  it('adds fetcherOptions to the request from the context', done => {
+  it('supports using a GET request', done => {
+    const variables = { params: 'stub' };
+    const link = createHttpLink({
+      uri: 'data',
+      fetchOptions: { method: 'GET' },
+    });
+
+    execute(link, { query: sampleQuery, variables }).subscribe(result => {
+      const method = fetchMock.lastCall()[1].method;
+      expect(method).toBe('GET');
+      done();
+    });
+  });
+  it('supports using a GET request on the context', done => {
+    const variables = { params: 'stub' };
+    const link = createHttpLink({
+      uri: 'data',
+    });
+
+    execute(link, {
+      query: sampleQuery,
+      variables,
+      context: {
+        fetchOptions: { method: 'GET' },
+      },
+    }).subscribe(result => {
+      const method = fetchMock.lastCall()[1].method;
+      expect(method).toBe('GET');
+      done();
+    });
+  });
+  it('adds fetchOptions to the request from the context', done => {
     const variables = { params: 'stub' };
     const middleware = new ApolloLink((operation, forward) => {
       operation.setContext({
-        fetcherOptions: {
+        fetchOptions: {
           signal: 'foo',
         },
       });
@@ -364,14 +397,14 @@ describe('HttpLink', () => {
     const variables = { params: 'stub' };
     const middleware = new ApolloLink((operation, forward) => {
       operation.setContext({
-        fetcherOptions: {
+        fetchOptions: {
           signal: 'foo',
         },
       });
       return forward(operation);
     });
     const link = middleware.concat(
-      createHttpLink({ uri: 'data', fetcherOptions: { signal: 'bar' } }),
+      createHttpLink({ uri: 'data', fetchOptions: { signal: 'bar' } }),
     );
 
     execute(link, { query: sampleQuery, variables }).subscribe(result => {

--- a/packages/apollo-link-http/src/httpLink.ts
+++ b/packages/apollo-link-http/src/httpLink.ts
@@ -90,7 +90,7 @@ export interface FetchOptions {
   includeExtensions?: boolean;
   credentials?: string;
   headers?: any;
-  fetcherOptions?: any;
+  fetchOptions?: any;
 }
 export const createHttpLink = (
   {
@@ -111,7 +111,11 @@ export const createHttpLink = (
   return new ApolloLink(
     operation =>
       new Observable(observer => {
-        const { headers, credentials, fetcherOptions } = operation.getContext();
+        const {
+          headers,
+          credentials,
+          fetchOptions = {},
+        } = operation.getContext();
         const { operationName, extensions, variables, query } = operation;
 
         const body = {
@@ -132,10 +136,10 @@ export const createHttpLink = (
           throw parseError;
         }
 
-        let options = fetcherOptions;
-        if (requestOptions.fetcherOptions)
-          options = { ...requestOptions.fetcherOptions, ...options };
-        const fetchOptions = {
+        let options = fetchOptions;
+        if (requestOptions.fetchOptions)
+          options = { ...requestOptions.fetchOptions, ...options };
+        const fetcherOptions = {
           method: 'POST',
           ...options,
           headers: {
@@ -147,21 +151,21 @@ export const createHttpLink = (
         };
 
         if (requestOptions.credentials)
-          fetchOptions.credentials = requestOptions.credentials;
-        if (credentials) fetchOptions.credentials = credentials;
+          fetcherOptions.credentials = requestOptions.credentials;
+        if (credentials) fetcherOptions.credentials = credentials;
 
         if (requestOptions.headers)
-          fetchOptions.headers = {
-            ...fetchOptions.headers,
+          fetcherOptions.headers = {
+            ...fetcherOptions.headers,
             ...requestOptions.headers,
           };
         if (headers)
-          fetchOptions.headers = { ...fetchOptions.headers, ...headers };
+          fetcherOptions.headers = { ...fetcherOptions.headers, ...headers };
 
         const { controller, signal } = createSignalIfSupported();
-        if (controller) fetchOptions.signal = signal;
+        if (controller) fetcherOptions.signal = signal;
 
-        fetcher(uri, fetchOptions)
+        fetcher(uri, fetcherOptions)
           .then(parseAndCheckResponse(operation))
           .then(result => {
             // we have data and can send it to back up the link chain


### PR DESCRIPTION
In response to https://github.com/apollographql/apollo-link/issues/153, this PR fixes the library to match the README. It also adds a default object to the context's fetchOptions to ensure object.assign doesn't try and spread undefined