### PR TITLE
docs(apollo-error): fixed typo in readme

### DIFF
--- a/packages/apollo-link-error/README.md
+++ b/packages/apollo-link-error/README.md
@@ -15,7 +15,7 @@ const link = onError(({ graphQLErrors, networkError }) => {
   if (graphQLErrors)
     graphQLErrors.map(({ message, locations, path }) =>
       console.log(
-        `[GraphQL error]: Message: ${message}, Location: ${location}, Path: ${path}`,
+        `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`,
       ),
     );
   if (networkError) console.log(`[Network error]: ${networkError}`);


### PR DESCRIPTION
## Issue
There was a typo in the readme for apollo-link-error. The variable referenced was incorrect, and I got an error mentioning something about referencing the global location variable. So I added an `s`.

## Changes
- Added an `s` 🔥🤘

