### PR TITLE
BatchHttpLink Docs - Fixed import

### DIFF
--- a/packages/apollo-link-batch-http/README.md
+++ b/packages/apollo-link-batch-http/README.md
@@ -39,7 +39,7 @@ import ApolloClient from "apollo-client";
 import InMemoryCache from "apollo-cache-inmemory";
 
 const client = new ApolloClient({
-  link: new BatchLink({ uri: "/graphql" }),
+  link: new BatchHttpLink({ uri: "/graphql" }),
   cache: new InMemoryCache()
 });
 

--- a/packages/apollo-link-batch-http/README.md
+++ b/packages/apollo-link-batch-http/README.md
@@ -9,9 +9,9 @@ An Apollo Link to allow batching of multiple operations into a single http reque
 
 ## Usage
 ```js
-import { BatchLink } from "apollo-link-batch-http";
+import { BatchHttpLink } from "apollo-link-batch-http";
 
-const link = new BatchLink({ uri: "/graphql" });
+const link = new BatchHttpLink({ uri: "/graphql" });
 ```
 
 ## Options
@@ -34,7 +34,7 @@ The Batch HTTP Link uses the `headers` field on the context to allow passing hea
 |headers|Headers (or object)|{}|false|
 
 ```js
-import BatchLink from "apollo-link-batch-http";
+import { BatchHttpLink } from "apollo-link-batch-http";
 import ApolloClient from "apollo-client";
 import InMemoryCache from "apollo-cache-inmemory";
 


### PR DESCRIPTION
## Issue
- the imports in the readme don't match what's exported. The default export is not a constructor, and `BatchLink` is not a named export.

## Changes
- changed both to `import { BatchHttpLink } from 'apollo-link-batch-http'`