### PR TITLE
added a fromPromise to convert a promise into an observable as a util

### DIFF
--- a/packages/apollo-link/CHANGELOG.md
+++ b/packages/apollo-link/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Change log
 
 ### vNEXT
+- added support for a `fromPromise` to make it easy to create an observable from a promise fetcher
+
+# 0.8.0
 - added support for `extensions` on an operation
+
+# 0.7.0
+- new operation API and start of changelog

--- a/packages/apollo-link/src/__tests__/linkUtils.ts
+++ b/packages/apollo-link/src/__tests__/linkUtils.ts
@@ -1,19 +1,15 @@
-import * as LinkUtils from '../linkUtils';
+import { validateOperation, fromPromise, makePromise } from '../linkUtils';
 import * as Observable from 'zen-observable';
 
 describe('Link utilities:', () => {
   describe('validateOperation', () => {
     it('should throw when invalid field in operation', () => {
-      expect(() =>
-        LinkUtils.validateOperation(<any>{
-          qwerty: '',
-        }),
-      ).toThrow();
+      expect(() => validateOperation(<any>{ qwerty: '' })).toThrow();
     });
 
     it('should throw when missing a query of some kind', () => {
       expect(() =>
-        LinkUtils.validateOperation(<any>{
+        validateOperation(<any>{
           query: '',
         }),
       ).toThrow();
@@ -21,7 +17,7 @@ describe('Link utilities:', () => {
 
     it('should not throw when valid fields in operation', () => {
       expect(() =>
-        LinkUtils.validateOperation({
+        validateOperation({
           query: '1234',
           context: {},
           variables: {},
@@ -39,15 +35,13 @@ describe('Link utilities:', () => {
     const error = new Error('I always error');
 
     it('return next call as Promise resolution', () => {
-      return LinkUtils.makePromise(Observable.of(data)).then(result =>
+      return makePromise(Observable.of(data)).then(result =>
         expect(data).toEqual(result),
       );
     });
 
     it('return error call as Promise rejection', () => {
-      return LinkUtils.makePromise(
-        new Observable(observer => observer.error(error)),
-      )
+      return makePromise(new Observable(observer => observer.error(error)))
         .then(expect.fail)
         .catch(actualError => expect(error).toEqual(actualError));
     });
@@ -66,12 +60,34 @@ describe('Link utilities:', () => {
       });
 
       it('return error call as Promise rejection', done => {
-        LinkUtils.makePromise(Observable.of(data, data)).then(result => {
+        makePromise(Observable.of(data, data)).then(result => {
           expect(data).toEqual(result);
           expect(spy).toHaveBeenCalled();
           done();
         });
       });
+    });
+  });
+  describe('fromPromise', () => {
+    const data = {
+      data: {
+        hello: 'world',
+      },
+    };
+    const error = new Error('I always error');
+
+    it('return next call as Promise resolution', () => {
+      const observable = fromPromise(Promise.resolve(data));
+      return makePromise(observable).then(result =>
+        expect(data).toEqual(result),
+      );
+    });
+
+    it('return Promise rejection as error call', () => {
+      const observable = fromPromise(Promise.reject(error));
+      return makePromise(observable)
+        .then(expect.fail)
+        .catch(actualError => expect(error).toEqual(actualError));
     });
   });
 });

--- a/packages/apollo-link/src/linkUtils.ts
+++ b/packages/apollo-link/src/linkUtils.ts
@@ -35,7 +35,7 @@ export function isTerminating(link: ApolloLink): boolean {
   return link.request.length <= 1;
 }
 
-export function makePromise<R>(observable: Observable<R>): Promise<R> {
+export function toPromise<R>(observable: Observable<R>): Promise<R> {
   let completed = false;
   return new Promise<R>((resolve, reject) => {
     observable.subscribe({
@@ -51,6 +51,20 @@ export function makePromise<R>(observable: Observable<R>): Promise<R> {
       },
       error: reject,
     });
+  });
+}
+
+// backwards compat
+export const makePromise = toPromise;
+
+export function fromPromise<T>(promise: Promise<T>): Observable<T> {
+  return new Observable<T>(observer => {
+    promise
+      .then((value: T) => {
+        observer.next(value);
+        observer.complete();
+      })
+      .catch(observer.error.bind(observer));
   });
 }
 


### PR DESCRIPTION
This is a simple util that makes is super easy to create an Apollo Link on top of an existing promise based API. For example:

```js
import { ApolloLink, fromPromise } from 'apollo-link';

const localGraphQLLink = new ApolloLink((operation) => {
  const { operation, variables } = operation;
  return fromPromise(graphql(schema, operation, variables))
})
```