### PR TITLE
Make apollo-link-ws a peer dependency

### DIFF
--- a/packages/apollo-link-ws/package.json
+++ b/packages/apollo-link-ws/package.json
@@ -40,10 +40,10 @@
     "watch": "tsc -w -p ."
   },
   "dependencies": {
-    "subscriptions-transport-ws": "^0.9.0"
   },
   "peerDependencies": {
-    "apollo-link": "^1.0.0"
+    "apollo-link": "^1.0.0",
+    "subscriptions-transport-ws": "^0.9.0"
   },
   "devDependencies": {
     "@types/graphql": "0.11.5",


### PR DESCRIPTION
Otherwise ...

````
if (paramsOrClient instanceof SubscriptionClient) {
            _this.subscriptionClient = paramsOrClient;
        }

````

sees a Subscription client of 0.9.1 as a params object

<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
- [ ] Add your name and email to the AUTHORS file (optional)
- [ ] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
