### PR TITLE
Add @types/zen-observable to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
   "pre-commit": "lint-staged",
   "dependencies": {},
   "devDependencies": {
+    "@types/zen-observable": "^0.5.3",
     "bundlesize": "0.15.3",
     "codecov": "3.0.0",
     "danger": "1.2.0",


### PR DESCRIPTION
`apollo-link` should depend on @types/zen-observable: https://pastebin.com/PL7QtAHA