### PR TITLE
Fix how BatchLink and BatchHttpLink were mocked in the BatchHttpLink test

### DIFF
--- a/packages/apollo-link-batch-http/src/__tests__/batchHttpLink.ts
+++ b/packages/apollo-link-batch-http/src/__tests__/batchHttpLink.ts
@@ -25,10 +25,11 @@ describe('BatchHttpLink', () => {
 
   it('should pass batchInterval and batchMax to BatchLink', () => {
     jest.mock('apollo-link-batch', () => ({
-      default: jest.fn(),
+      BatchLink: jest.fn(),
     }));
-    const BatchLink = require('apollo-link-batch').default;
-    const LocalScopedLink = require('../batchHttpLink').default;
+
+    const BatchLink = require('apollo-link-batch').BatchLink;
+    const LocalScopedLink = require('../batchHttpLink').BatchHttpLink;
 
     const batch = new LocalScopedLink({
       batchInterval: 20,


### PR DESCRIPTION
While playing with the apollo-link codebase I noticed that out of the box the master branch test's fail:
```
BatchHttpLink
    ✓ does not need any constructor arguments (2ms)
    ✕ should pass batchInterval and batchMax to BatchLink (198ms)
    ✓ should pass printed operation to apollo fetch (58ms)
    ✓ should call observer's error when apollo fetch returns an error (13ms)
    ✓ should call observer's next and then complete when apollo fetch returns data (16ms)

  ● BatchHttpLink › should pass batchInterval and batchMax to BatchLink

    TypeError: LocalScopedLink is not a constructor
      
      at Object.<anonymous> (src/__tests__/batchHttpLink.ts:33:19)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)
```
Seems to be an issue with the way the BatchHttpLink and BatchLink were mocked, I have fixed them in this PR and now all of the tests complete as expected.