### PR TITLE
Link to docs on the website instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Apollo Link uses Lerna to manage multiple packages. To get started contributing,
 
 ## Documentation
 
-To start, begin by reading the getting started [guide](docs/source/index.md).
+To start, begin by reading the getting started [guide](http://apollo-link-docs.netlify.com/docs/link/index.html).
 
-If you are interested in implementing your own links, read the implementation [information](docs/source/overview.md).
+If you are interested in implementing your own links, read the implementation [information](http://apollo-link-docs.netlify.com/docs/link/overview.html).
 
 Your feedback and contributions are welcome.
 


### PR DESCRIPTION
... because the docs in the repo have dead links (.html instead of .md)
