### PR TITLE
support response on context and dynamic endpoints

### DIFF
--- a/packages/apollo-link-http/CHANGELOG.md
+++ b/packages/apollo-link-http/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change log
 
 ### vNEXT
+- support dynamic endpoints using `uri` on the context
+- the request not attaches the raw response as `response` on the context. This can be used to access response headers or more
+
+### v1.0.0
+- official release, not changes
 
 ### v0.9.0
 - changed `fetcherOptions` to be `fetchOptions` and added a test for using 'GET' requests

--- a/packages/apollo-link-http/README.md
+++ b/packages/apollo-link-http/README.md
@@ -36,10 +36,15 @@ HTTP Link takes an object with some options on it to customize the behavior of t
 
 
 ## Context
-The Http Link uses the `headers` field on the context to allow passing headers to the HTTP request. It also supports the `credentials` field for defining credentials policy for fetch and `fetchOptions` to allow generic fetch overrides (i.e. method: "GET"). These options will override the same key if passed when creating the the link.
+The Http Link uses the `headers` field on the context to allow passing headers to the HTTP request. It also supports the `credentials` field for defining credentials policy, `uri` for changing the endpoint dynamically, and `fetchOptions` to allow generic fetch overrides (i.e. method: "GET"). These options will override the same key if passed when creating the the link.
+
+This link also attaches the response from the `fetch` operation on the context as `response` so you can access it from within another link.
+
 - `headers`: an object representing values to be sent as headers on the request
 - `credentials`: a string representing the credentials policy you want for the fetch call
+- `uri`: a string of the endpoint you want to fetch from
 - `fetchOptions`: any overrides of the fetch options argument to pass to the fetch call
+- `response`: this is the raw response from the fetch request after it is made.
 
 
 ```js

--- a/packages/apollo-link-http/src/__tests__/httpLink.ts
+++ b/packages/apollo-link-http/src/__tests__/httpLink.ts
@@ -23,15 +23,18 @@ const sampleMutation = gql`
 
 describe('HttpLink', () => {
   const data = { data: { hello: 'world' } };
+  const data2 = { data: { hello: 'everyone' } };
   const mockError = { throws: new TypeError('mock me') };
 
   let subscriber;
 
   beforeEach(() => {
+    fetchMock.post('begin:data2', data2);
     fetchMock.post('begin:data', data);
     fetchMock.post('begin:error', mockError);
 
     fetchMock.get('begin:data', data);
+    fetchMock.get('begin:data2', data2);
 
     const next = jest.fn();
     const error = jest.fn();
@@ -214,14 +217,30 @@ describe('HttpLink', () => {
       done();
     }, 50);
   });
+  it('allows for dynamic endpoint setting', done => {
+    const variables = { params: 'stub' };
+    const link = createHttpLink({ uri: 'data' });
 
+    execute(link, {
+      query: sampleQuery,
+      variables,
+      context: { uri: 'data2' },
+    }).subscribe(result => {
+      expect(result).toEqual(data2);
+      done();
+    });
+  });
   it('adds headers to the request from the context', done => {
     const variables = { params: 'stub' };
     const middleware = new ApolloLink((operation, forward) => {
       operation.setContext({
         headers: { authorization: '1234' },
       });
-      return forward(operation);
+      return forward(operation).map(result => {
+        const { response } = operation.getContext();
+        expect(response.headers).toBeDefined();
+        return result;
+      });
     });
     const link = middleware.concat(createHttpLink({ uri: 'data' }));
 

--- a/packages/apollo-link-http/src/httpLink.ts
+++ b/packages/apollo-link-http/src/httpLink.ts
@@ -115,6 +115,7 @@ export const createHttpLink = (
           headers,
           credentials,
           fetchOptions = {},
+          uri: endpoint,
         } = operation.getContext();
         const { operationName, extensions, variables, query } = operation;
 
@@ -165,7 +166,12 @@ export const createHttpLink = (
         const { controller, signal } = createSignalIfSupported();
         if (controller) fetcherOptions.signal = signal;
 
-        fetcher(uri, fetcherOptions)
+        fetcher(endpoint || uri, fetcherOptions)
+          // attach the raw response to the context for usage
+          .then(response => {
+            operation.setContext({ response });
+            return response;
+          })
           .then(parseAndCheckResponse(operation))
           .then(result => {
             // we have data and can send it to back up the link chain


### PR DESCRIPTION
This PR adds a couple fun / powerful features to the http-link.

### Dynamic endpoints
If you app needs to talk to multiple GraphQL backends, but you want to manage all of that data with one client, now you can! Each request can overwrite the initial `uri` by using the `context` of the request. Simply pass `{ context: { uri: 'api2.example.com' } }` to your operation and it will route that request accordingly!

*Note* this will not replace your default, it will only change for the lifespan of that request.

### Raw response
Sometimes having the raw response from your fetch is super helpful for afterware, especially for authentication needs. Now you can access the raw response from any other link by seeing if `operation.getContext().response` is present. This will only be present after a request is made so you need to call `getContext()` within a `.map` or custom subscriber of the `forward(operation)` request in your custom link. 

*Note* if you are using this, please let me know so we can work together to write a recipe for the docs for it!!

huzzah!
