### PR TITLE
feat(link): added dev tools hooks

### DIFF
--- a/packages/apollo-link/package.json
+++ b/packages/apollo-link/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@types/zen-observable": "0.5.3",
-    "apollo-utilities": "^1.0.0",
+    "apollo-utilities": "^1.0.1",
     "zen-observable": "^0.6.0"
   },
   "peerDependencies": {

--- a/packages/apollo-link/src/__tests__/link.ts
+++ b/packages/apollo-link/src/__tests__/link.ts
@@ -428,7 +428,8 @@ describe('Link static library', () => {
             query: sampleQuery,
             variables: {},
           }).toEqual(op);
-          return done();
+          done();
+          return Observable.of();
         }),
       ]);
       execute(chain, uniqueOperation);
@@ -718,36 +719,6 @@ describe('Link static library', () => {
     it('should return an empty observable when a link is empty', done => {
       testLinkResults({
         link: ApolloLink.empty(),
-        results: [],
-        done,
-      });
-    });
-
-    it("should return an empty observable when a concat'd link returns null", done => {
-      const link = new MockLink((operation, forward) => {
-        return forward(operation);
-      }).concat(() => null);
-      testLinkResults({
-        link,
-        results: [],
-        done,
-      });
-    });
-
-    it('should return an empty observable when a split link returns null', done => {
-      let context = { test: true };
-      const link = new SetContextLink(() => context).split(
-        op => op.getContext().test,
-        () => Observable.of(),
-        () => null,
-      );
-      testLinkResults({
-        link,
-        results: [],
-      });
-      context.test = false;
-      testLinkResults({
-        link,
         results: [],
         done,
       });

--- a/packages/apollo-link/src/test-utils/mockLink.ts
+++ b/packages/apollo-link/src/test-utils/mockLink.ts
@@ -5,7 +5,7 @@ import * as Observable from 'zen-observable';
 import { ApolloLink } from '../link';
 
 export default class MockLink extends ApolloLink {
-  constructor(handleRequest: RequestHandler = () => null) {
+  constructor(handleRequest: RequestHandler = () => Observable.of()) {
     super();
     this.request = handleRequest;
   }
@@ -13,7 +13,7 @@ export default class MockLink extends ApolloLink {
   public request(
     operation: Operation,
     forward?: NextLink,
-  ): Observable<FetchResult> | null {
+  ): Observable<FetchResult> {
     throw Error('should be overridden');
   }
 }

--- a/packages/apollo-link/src/types.ts
+++ b/packages/apollo-link/src/types.ts
@@ -31,4 +31,13 @@ export type NextLink = (operation: Operation) => Observable<FetchResult>;
 export type RequestHandler = (
   operation: Operation,
   forward?: NextLink,
-) => Observable<FetchResult> | null;
+) => Observable<FetchResult>;
+
+export type DevToolsMessage = {
+  network: {
+    operation: Operation;
+    result: FetchResult;
+  };
+};
+
+export type DevToolsHook = (message: DevToolsMessage) => void;


### PR DESCRIPTION
- added execute method to wrap request and notify dev tools (this is 100% working, I was able to log the data to the console)
- added connectToDevTools method to save `this.devToolsHookCb` from `apollo-client` to the class
- added notifyDevTools method that invokes the dev tools hook with the data

@jbaxleyiii Due to all the weird npm link issues, @stubailo recommended that we should just publish a prerelease of apollo-link. What do you think?