### PR TITLE
fix bug in dedup link

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,47 +23,47 @@
     {
       "name": "apollo-link",
       "path": "./packages/apollo-link/lib/bundle.min.js",
-      "threshold": "1.6 Kb"
+      "maxSize": "3 Kb"
     },
     {
       "name": "apollo-link-batch",
       "path": "./packages/apollo-link-batch/lib/bundle.min.js",
-      "threshold": "1.3 Kb"
+      "maxSize": "1.3 Kb"
     },
     {
       "name": "apollo-link-batch-http",
       "path": "./packages/apollo-link-batch-http/lib/bundle.min.js",
-      "threshold": "6.5 Kb"
+      "maxSize": "6.5 Kb"
     },
     {
       "name": "apollo-link-dedup",
       "path": "./packages/apollo-link-dedup/lib/bundle.min.js",
-      "threshold": "3 Kb"
+      "maxSize": "3 Kb"
     },
     {
       "name": "apollo-link-error",
       "path": "./packages/apollo-link-error/lib/bundle.min.js",
-      "threshold": "1 Kb"
+      "maxSize": "1 Kb"
     },
     {
       "name": "apollo-link-http",
       "path": "./packages/apollo-link-http/lib/bundle.min.js",
-      "threshold": "3.8 Kb"
+      "maxSize": "4 Kb"
     },
     {
       "name": "apollo-link-polling",
       "path": "./packages/apollo-link-polling/lib/bundle.min.js",
-      "threshold": "1 Kb"
+      "maxSize": "1 Kb"
     },
     {
       "name": "apollo-link-retry",
       "path": "./packages/apollo-link-retry/lib/bundle.min.js",
-      "threshold": "1 Kb"
+      "maxSize": "1 Kb"
     },
     {
       "name": "apollo-link-ws",
       "path": "./packages/apollo-link-ws/lib/bundle.min.js",
-      "threshold": "10 Kb"
+      "maxSize": "10 Kb"
     }
   ],
   "jest": {

--- a/packages/apollo-link-dedup/CHANGELOG.md
+++ b/packages/apollo-link-dedup/CHANGELOG.md
@@ -1,3 +1,6 @@
 
-### vNext
+### 1.0.1
+- fixed bug where next observable subscription was not deduplicated
+
+### 1.0.0
 - moved from default export to named to be consistent with rest of link ecosystem

--- a/packages/apollo-link-dedup/src/__tests__/dedupLink.ts
+++ b/packages/apollo-link-dedup/src/__tests__/dedupLink.ts
@@ -65,7 +65,7 @@ describe('DedupLink', () => {
     const variables = { x: 'Hello World' };
 
     let error;
-    const data = { data: { data: 'some data' } };
+    const data = { data: 'some data' };
 
     const request: GraphQLRequest = {
       query: document,
@@ -96,20 +96,24 @@ describe('DedupLink', () => {
       }),
     ]);
 
-    execute(deduper, request).subscribe({
-      error: actualError => {
-        expect(actualError).toEqual(error);
+    try {
+      execute(deduper, request).subscribe({
+        error: actualError => {
+          expect(actualError).toEqual(error);
 
-        //second query
-        execute(deduper, request).subscribe({
-          next: result => {
-            expect(result).toEqual(data);
-            expect(called).toBe(2);
-            done();
-          },
-        });
-      },
-    });
+          //second query
+          execute(deduper, request).subscribe({
+            next: result => {
+              expect(result).toEqual(data);
+              expect(called).toBe(2);
+              done();
+            },
+          });
+        },
+      });
+    } catch (e) {
+      done.fail(e);
+    }
   });
 
   it(`deduplicates identical queries`, () => {
@@ -137,8 +141,8 @@ describe('DedupLink', () => {
     const deduper = ApolloLink.from([
       new DedupLink(),
       new ApolloLink(() => {
-        called += 1;
         return new Observable(observer => {
+          called += 1;
           setTimeout(observer.complete.bind(observer));
         });
       }),

--- a/packages/apollo-link-dedup/src/dedupLink.ts
+++ b/packages/apollo-link-dedup/src/dedupLink.ts
@@ -10,14 +10,11 @@ import {
  * Expects context to contain the forceFetch field if no dedup
  */
 export class DedupLink extends ApolloLink {
-  private inFlightRequestObservables: {
-    [key: string]: Observable<FetchResult>;
-  };
-
-  constructor() {
-    super();
-    this.inFlightRequestObservables = {};
-  }
+  private inFlightRequestObservables: Map<
+    string,
+    Observable<FetchResult>
+  > = new Map();
+  private subscribers: Map<string, any> = new Map();
 
   public request(
     operation: Operation,
@@ -29,26 +26,65 @@ export class DedupLink extends ApolloLink {
     }
 
     const key = operation.toKey();
-    if (!this.inFlightRequestObservables[key]) {
-      this.inFlightRequestObservables[key] = forward(operation);
-    }
-    return new Observable<FetchResult>(observer => {
-      const subscription = this.inFlightRequestObservables[key].subscribe({
-        next: result => {
-          delete this.inFlightRequestObservables[key];
-          observer.next(result);
-        },
-        error: error => {
-          delete this.inFlightRequestObservables[key];
-          observer.error(error);
-        },
-        complete: observer.complete.bind(observer),
+
+    const cleanup = key => {
+      this.inFlightRequestObservables.delete(key);
+      const prev = this.subscribers.get(key);
+      this.subscribers.delete(key);
+      return prev;
+    };
+
+    if (!this.inFlightRequestObservables.get(key)) {
+      // this is a new request, i.e. we haven't deduplicated it yet
+      // call the next link
+      const singleObserver = forward(operation);
+      let subscription;
+
+      const sharedObserver = new Observable(observer => {
+        // this will still be called by each subscriber regardless of
+        // deduplication status
+        let prev = this.subscribers.get(key);
+        if (!prev) {
+          prev = {
+            next: [],
+            error: [],
+            complete: [],
+          };
+        }
+
+        this.subscribers.set(key, {
+          next: prev.next.concat([observer.next.bind(observer)]),
+          error: prev.error.concat([observer.error.bind(observer)]),
+          complete: prev.complete.concat([observer.complete.bind(observer)]),
+        });
+
+        if (!subscription) {
+          subscription = singleObserver.subscribe({
+            next: result => {
+              const prev = cleanup(key);
+              if (prev) prev.next.forEach(next => next(result));
+            },
+            error: error => {
+              const prev = cleanup(key);
+              if (prev) prev.error.forEach(err => err(error));
+            },
+            complete: () => {
+              const prev = cleanup(key);
+              if (prev) prev.complete.forEach(complete => complete());
+            },
+          });
+        }
+
+        return () => {
+          cleanup(key);
+          if (subscription) subscription.unsubscribe();
+        };
       });
 
-      return () => {
-        if (subscription) subscription.unsubscribe();
-        delete this.inFlightRequestObservables[key];
-      };
-    });
+      this.inFlightRequestObservables.set(key, sharedObserver);
+    }
+
+    // return shared Observable
+    return this.inFlightRequestObservables.get(key);
   }
 }


### PR DESCRIPTION
Previously, this package deduplicated calls to further apollo-links, however, do to the way observables + subscriptions work, the new link was still called in many cases. This makes the logic a little more complex but these changes fix the problem.

Reported (among other places) [here](https://github.com/apollographql/apollo-client/issues/2463) and [here](https://github.com/apollographql/apollo-client/issues/2391)