### PR TITLE
Add Clarity around Http Link Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Some common choices include Browserify, Webpack, and Meteor +1.3.
 
 
 ## Contributing
-Apollo Link uses Lerna to manage multiple packages. To get started contributing, run `npm run bootstrap` which will install all dependencies and link together the projects.
+Apollo Link uses Lerna to manage multiple packages. To get started contributing, run `npm run bootstrap` which will install all dependencies and connect the dependent projects with symlinks `node_modules`.
 
 ## Documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,16 @@
-# docs
+# Apollo Link docs
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/apollographql/react-docs.svg)](https://greenkeeper.io/)
+[![Greenkeeper badge](https://badges.greenkeeper.io/apollographql/apollo-link.svg)](https://greenkeeper.io/)
 
-To run:
+To run the documents locally, please use the following commands:
 
 ```
-git clone --recursive https://github.com/apollographql/react-docs.git
-cd react-docs
+git submodule init
+git submodule update
 npm install
 npm start
 ```
+
+These instructions will start a hexo server on [localhost's 4000 port](http://localhost:4000/docs/link/). For more information about the doc framework visit the [hexo website](https://hexo.io/).
+
+Thank you for thinking about adding to Apollo Documentation! Quality documentation is always appreciated.

--- a/packages/apollo-link-error/CHANGELOG.md
+++ b/packages/apollo-link-error/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change log
 
 ### vNEXT
+- apollo-link-http: Added clarity around errors: ClientParseError, ServerParseError, and ServerError(Network and Missing Data)
+- apollo-link-error: graphQLErrors alias networkError.result.errors on a networkError
 
 ### 1.0.1
 - moved to better rollup build

--- a/packages/apollo-link-error/README.md
+++ b/packages/apollo-link-error/README.md
@@ -31,7 +31,7 @@ Error Link takes a function that is called in the event of an error. This functi
 - `graphQLErrors`: An array of errors from the GraphQL endpoint
 - `networkError`: any error during the link execution or server response
 
-*Note*: `networkError` is the value from the downlink's `error` callback. On the other hand, `graphQLErrors` is the `errors` field of the result from the most recent `next` call. A `networkError` can contain additional fields, such as a GraphQL object in the case of a [failing HTTP status code](http.html#Errors) from [`apollo-link-http`](http.html).
+*Note*: `networkError` is the value from the downlink's `error` callback. In most cases, `graphQLErrors` is the `errors` field of the result from the last `next` call. A `networkError` can contain additional fields, such as a GraphQL object in the case of a [failing HTTP status code](http.html#Errors) from [`apollo-link-http`](http.html). In this situation, `graphQLErrors` is an alias for `networkError.result.errors` if the property exists.
 
 ### Ignoring errors
 If you want to conditionally ignore errors, you can set `response.errors = null;` within the error handler:

--- a/packages/apollo-link-error/README.md
+++ b/packages/apollo-link-error/README.md
@@ -31,6 +31,8 @@ Error Link takes a function that is called in the event of an error. This functi
 - `graphQLErrors`: An array of errors from the GraphQL endpoint
 - `networkError`: any error during the link execution or server response
 
+*Note*: `networkError` is the value from the downlink's `error` callback. On the other hand, `graphQLErrors` is the `errors` field of the result from the most recent `next` call. A `networkError` can contain additional fields, such as a GraphQL object in the case of a [failing HTTP status code](http.html#Errors) from [`apollo-link-http`](http.html).
+
 ### Ignoring errors
 If you want to conditionally ignore errors, you can set `response.errors = null;` within the error handler:
 

--- a/packages/apollo-link-error/src/index.ts
+++ b/packages/apollo-link-error/src/index.ts
@@ -30,6 +30,8 @@ export const onError = (errorHandler: ErrorHandler): ApolloLink => {
             errorHandler({
               operation,
               networkError,
+              //Network errors can return GraphQL errors on for example a 403
+              graphQLErrors: networkError.result && networkError.result.errors,
             });
             observer.error(networkError);
           },

--- a/packages/apollo-link-http/README.md
+++ b/packages/apollo-link-http/README.md
@@ -29,7 +29,7 @@ The HTTP Link relies on having `fetch` present in your runtime environment. If y
 HTTP Link takes an object with some options on it to customize the behavior of the link. If your server supports it, the HTTP link can also send over metadata about the request in the extensions field. To enable this, pass `includeExtensions` as true. The options you can pass are outlined below:
 - `uri`: the URI key can be either a string endpoint or default to "/graphql"
 - `includeExtensions`: allow passing the extensions field to your graphql server, defaults to false
-- `fetch`: a `fetch` compatiable API for making a request 
+- `fetch`: a `fetch` compatiable API for making a request
 - `headers`: an object representing values to be sent as headers on the request
 - `credentials`: a string representing the credentials policy you want for the fetch call
 - `fetchOptions`: any overrides of the fetch options argument to pass to the fetch call
@@ -86,7 +86,48 @@ client.query({
 })
 ```
 
-## Upgrading from `apollo-fetch` / `apollo-client` 
+## Errors
+The Http Link draws a distinction between client, server and GraphQL errors.
+Server errors can occur in three different scenerios: parse, network and data errors.
+This list describes the different errors and what the response Observable calls:
+
+* Client parse errors: the request body is not-serializable due to circular references for example
+* Server parse errors: the response from the server cannot be parsed((response.json())[https://developer.mozilla.org/en-US/docs/Web/API/Body/json])
+* Server network errors: the response has a status of >= 300
+* Server data errors:  the parse request does not contain `data` or `errors`
+* GraphQL errors: an objects in the `errors` array for a 200 level status
+
+Since many server implementations can return a valid GraphQL result on a server network error, the thrown `Error` object contains the parsed server result.
+A server data error also receives the parsed result.
+
+This table provides a summary of the errors, the `Observable` method called by the HTTP link, and type of the error thrown.
+
+| Error   |      Callback      |Error Type |
+|----------|:-------------:|------|
+| Client Parse |    `error`   | `ClientParseError` |
+| Server Parse |    `error`   | `ServerParseError` |
+| Server Network |    `error`   | `ServerError` |
+| Server Data |    `error`   | `ServerError` |
+| GraphQL Error |    `next`   | `` |
+
+```js
+type ServerError = Error & {
+  response: Response;
+  result: Record<string, any>;
+  statusCode: number;
+};
+
+type ServerParseError = Error & {
+  response: Response;
+  statusCode: number;
+};
+
+type ClientParseError = Error & {
+  parseError: Error;
+};
+```
+
+## Upgrading from `apollo-fetch` / `apollo-client`
 If you previously used either `apollo-fetch` or `apollo-client`, you will need to change the way `use` and `useAfter` are implemented in your app. Both can be implemented by writing a custom link. It's important to note that regardless of whether you're adding middleware or afterware, your Http link will always be last in the chain since it's a terminating link.
 
 #### Middleware

--- a/packages/apollo-link-http/README.md
+++ b/packages/apollo-link-http/README.md
@@ -87,48 +87,50 @@ client.query({
 ```
 
 ## Errors
-The Http Link draws a distinction between client, server and GraphQL errors.
-Server errors can occur in three different scenerios: parse, network and data errors.
-This list describes the different errors and what the response Observable calls:
+The Http Link draws a distinction between client, server and GraphQL errors. Server errors can occur in three different scenerios: parse, network and data errors. [`apollo-link-error`](error.html) provides an [interface](error.html#Usage) for handling these errors. This list describes the scenerios that cause different errors:
 
-* Client parse errors: the request body is not-serializable due to circular references for example
-* Server parse errors: the response from the server cannot be parsed((response.json())[https://developer.mozilla.org/en-US/docs/Web/API/Body/json])
-* Server network errors: the response has a status of >= 300
-* Server data errors:  the parse request does not contain `data` or `errors`
-* GraphQL errors: an objects in the `errors` array for a 200 level status
+* *Client parse error*: the request body is not-serializable due to circular references for example
+* *Server parse error*: the response from the server cannot be parsed ([response.json()](https://developer.mozilla.org/en-US/docs/Web/API/Body/json))
+* *Server network error*: the response has a status of >= 300
+* *Server data error*:  the parse request does not contain `data` or `errors`
+* *GraphQL error*: an objects in the `errors` array for a 200 level status
 
-Since many server implementations can return a valid GraphQL result on a server network error, the thrown `Error` object contains the parsed server result.
-A server data error also receives the parsed result.
+Since many server implementations can return a valid GraphQL result on a server network error, the thrown `Error` object contains the parsed server result. A server data error also receives the parsed result.
 
-This table provides a summary of the errors, the `Observable` method called by the HTTP link, and type of the error thrown.
+The table below provides a summary of error, `Observable` method called by the HTTP link, and type of error thrown for each failure:
 
 | Error   |      Callback      |Error Type |
 |----------|:-------------:|------|
 | Client Parse |    `error`   | `ClientParseError` |
 | Server Parse |    `error`   | `ServerParseError` |
-| Server Network |    `error`   | `ServerError` |
-| Server Data |    `error`   | `ServerError` |
-| GraphQL Error |    `next`   | `` |
+| Server Network |  `error`   | `ServerError` |
+| Server Data |     `error`   | `ServerError` |
+| GraphQL Error |   `next`    | `Object` |
+
+All error types inherit the `name`, `message`, and nullable `stack` properties from the generic javascript [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error).
 
 ```js
-type ServerError = Error & {
-  response: Response;
-  result: Record<string, any>;
-  statusCode: number;
+//type ClientParseError
+{
+  parseError: Error;                // Error returned from response.json()
 };
 
-type ServerParseError = Error & {
-  response: Response;
-  statusCode: number;
+//type ServerParseError
+{
+  response: Response;               // Object returned from fetch()
+  statusCode: number;               // HTTP status code
 };
 
-type ClientParseError = Error & {
-  parseError: Error;
+//type ServerError
+{
+  result: Record<string, any>;      // Parsed object from server response
+  response: Response;               // Object returned from fetch()
+  statusCode: number;               // HTTP status code
 };
 ```
 
 ## Upgrading from `apollo-fetch` / `apollo-client`
-If you previously used either `apollo-fetch` or `apollo-client`, you will need to change the way `use` and `useAfter` are implemented in your app. Both can be implemented by writing a custom link. It's important to note that regardless of whether you're adding middleware or afterware, your Http link will always be last in the chain since it's a terminating link.
+If you previously used either `apollo-fetch` or `apollo-client`'s `createNetworkInterface`, you will need to change the way `use` and `useAfter` are implemented in your app. Both can be implemented by writing a custom link. It's important to note that regardless of whether you're adding middleware or afterware, your Http link will always be last in the chain since it's a terminating link.
 
 #### Middleware
 

--- a/packages/apollo-link-http/src/httpLink.ts
+++ b/packages/apollo-link-http/src/httpLink.ts
@@ -7,38 +7,63 @@ import { ApolloFetch } from 'apollo-fetch';
 // XXX replace with actual typings when available
 declare var AbortController: any;
 
-type ResponseError = Error & {
-  response?: Response;
+//Used for any Error for data from the server
+//on a request with a Status >= 300
+//response contains no data or errors
+type ServerError = Error & {
+  response: Response;
+  result: Record<string, any>;
+  statusCode: number;
+};
+
+//Thrown when server's resonse is cannot be parsed
+type ServerParseError = Error & {
+  response: Response;
+  statusCode: number;
+};
+
+type ClientParseError = Error & {
   parseError: Error;
-  statusCode?: number;
+};
+
+const throwServerError = (response, result, message) => {
+  const error = new Error(message) as ServerError;
+
+  error.response = response;
+  error.statusCode = response.status;
+  error.result = result;
+
+  throw error;
 };
 
 const parseAndCheckResponse = request => (response: Response) => {
   return response
     .json()
+    .catch(e => {
+      const parseError = e as ServerParseError;
+      parseError.response = response;
+      parseError.statusCode = response.status;
+
+      throw parseError;
+    })
     .then(result => {
-      if (response.status >= 300)
-        throw new Error(
+      if (response.status >= 300) {
+        //Network error
+        throwServerError(
+          response,
+          result,
           `Response not successful: Received status code ${response.status}`,
         );
+      }
       if (!result.hasOwnProperty('data') && !result.hasOwnProperty('errors')) {
-        throw new Error(
+        //Data error
+        throwServerError(
+          response,
+          result,
           `Server response was missing for query '${request.operationName}'.`,
         );
       }
       return result;
-    })
-    .catch(e => {
-      const httpError = new Error(
-        `Network request failed with status ${response.status} - "${
-          response.statusText
-        }"`,
-      ) as ResponseError;
-      httpError.response = response;
-      httpError.parseError = e;
-      httpError.statusCode = response.status;
-
-      throw httpError;
     });
 };
 
@@ -141,7 +166,7 @@ export const createHttpLink = (
         } catch (e) {
           const parseError = new Error(
             `Network request failed. Payload is not serializable: ${e.message}`,
-          ) as ResponseError;
+          ) as ClientParseError;
           parseError.parseError = e;
           throw parseError;
         }
@@ -149,7 +174,7 @@ export const createHttpLink = (
         let options = fetchOptions;
         if (requestOptions.fetchOptions)
           options = { ...requestOptions.fetchOptions, ...options };
-        const fetcherOptions = {
+        const fetcherOptions: any = {
           method: 'POST',
           ...options,
           headers: {


### PR DESCRIPTION
We add the result to network and data errors along with documenting errors in the http link's README. This error documentation used to happen in Apollo Fetch and since we are no longer using it the behavior should be present here.

This modifies the error types in a backwards incompatible manner, removing the nullable fields from a client parse error.

The PR also adds a couple changes to the docs README to detail how to run them locally.

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] Add your name and email to the AUTHORS file (optional)
- [x] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
