### PR TITLE
allow http link to not send the query over the wire

### DIFF
--- a/packages/apollo-link-http/CHANGELOG.md
+++ b/packages/apollo-link-http/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- support for persisted queries by opting out of sending the query
 
 ### v1.1.0
 - support dynamic endpoints using `uri` on the context

--- a/packages/apollo-link-http/README.md
+++ b/packages/apollo-link-http/README.md
@@ -45,6 +45,23 @@ This link also attaches the response from the `fetch` operation on the context a
 - `uri`: a string of the endpoint you want to fetch from
 - `fetchOptions`: any overrides of the fetch options argument to pass to the fetch call
 - `response`: this is the raw response from the fetch request after it is made.
+- `http`: this is an object to control fine grained aspects of the http link itself (see below)
+
+**http options**
+The http link supports an advanced GraphQL feature (and maybe more in the future) called persisted queries. This allows you to not send the stringified query over the wire, but instead send some kind of identifier of the query. To support this you need to attach the id somewhere to the extensions field and pass the following options to the context:
+
+```
+operation.setContext({
+  http: {
+    includeExtensions: true,
+    includeQuery: false,
+  }
+})
+```
+
+the `http` object on context currently supports two keys:
+- `includeExtensions`: allowing you to send the extensions object per request
+- `includeQuery`: allowing you to not send a query as part of the request
 
 
 ```js

--- a/packages/apollo-link-http/src/httpLink.ts
+++ b/packages/apollo-link-http/src/httpLink.ts
@@ -134,7 +134,7 @@ export const createHttpLink = (
           (body as any).extensions = extensions;
 
         // not sending the query (i.e persisted queries)
-        if (http.includeQuery) body.query = print(query);
+        if (http.includeQuery) (body as any).query = print(query);
 
         let serializedBody;
         try {

--- a/packages/apollo-link-http/src/httpLink.ts
+++ b/packages/apollo-link-http/src/httpLink.ts
@@ -2,7 +2,6 @@ import { ApolloLink, Observable, RequestHandler } from 'apollo-link';
 import { print } from 'graphql/language/printer';
 
 // types
-import { ExecutionResult } from 'graphql';
 import { ApolloFetch } from 'apollo-fetch';
 
 // XXX replace with actual typings when available
@@ -207,11 +206,6 @@ export const createHttpLink = (
 export class HttpLink extends ApolloLink {
   public requester: RequestHandler;
   constructor(opts: FetchOptions) {
-    super();
-    this.requester = createHttpLink(opts).request;
-  }
-
-  public request(op): Observable<ExecutionResult> | null {
-    return this.requester(op);
+    super(createHttpLink(opts).request);
   }
 }

--- a/packages/apollo-link/src/__tests__/linkUtils.ts
+++ b/packages/apollo-link/src/__tests__/linkUtils.ts
@@ -7,14 +7,6 @@ describe('Link utilities:', () => {
       expect(() => validateOperation(<any>{ qwerty: '' })).toThrow();
     });
 
-    it('should throw when missing a query of some kind', () => {
-      expect(() =>
-        validateOperation(<any>{
-          query: '',
-        }),
-      ).toThrow();
-    });
-
     it('should not throw when valid fields in operation', () => {
       expect(() =>
         validateOperation({

--- a/packages/apollo-link/src/linkUtils.ts
+++ b/packages/apollo-link/src/linkUtils.ts
@@ -13,7 +13,6 @@ export function validateOperation(operation: GraphQLRequest): GraphQLRequest {
     'extensions',
     'context',
   ];
-  if (!operation.query) throw new Error('ApolloLink requires a query');
   for (let key of Object.keys(operation)) {
     if (OPERATION_FIELDS.indexOf(key) < 0) {
       throw new Error(`illegal argument: ${key}`);
@@ -122,7 +121,7 @@ export function createOperation(
 export function getKey(operation: GraphQLRequest) {
   // XXX we're assuming here that variables will be serialized in the same order.
   // that might not always be true
-  return `${print(operation.query)}|${JSON.stringify(
-    operation.variables,
-  )}|${operation.operationName}`;
+  return `${print(operation.query)}|${JSON.stringify(operation.variables)}|${
+    operation.operationName
+  }`;
 }


### PR DESCRIPTION
This setups the ability to send persisted queries of any kind using the http link. Instead of sending the query as part of the request, it can send the extensions field instead.