### PR TITLE
show advanced usage of fetching

### DIFF
--- a/packages/apollo-link-http/CHANGELOG.md
+++ b/packages/apollo-link-http/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change log
 
 ### vNEXT
-- added ability to generate URI based on operation
+
+### 1.3.0
+- changed to initially parsing response as text to improve error handling
 - cleaned up error handling types and added docs
 
 ### 1.2.0

--- a/packages/apollo-link-http/package.json
+++ b/packages/apollo-link-http/package.json
@@ -56,6 +56,7 @@
     "graphql": "0.11.7",
     "graphql-tag": "2.5.0",
     "jest": "21.2.1",
+    "object-to-querystring": "^1.0.4",
     "rimraf": "2.6.1",
     "rollup": "0.52.0",
     "ts-jest": "21.2.3",

--- a/packages/apollo-link-http/src/__tests__/httpLink.ts
+++ b/packages/apollo-link-http/src/__tests__/httpLink.ts
@@ -428,7 +428,7 @@ describe('HttpLink', () => {
       done();
     });
   });
-  fit('supports using a GET request', done => {
+  it('supports using a GET request', done => {
     const variables = { params: 'stub' };
 
     let requestedString;

--- a/packages/apollo-link-http/src/__tests__/httpLink.ts
+++ b/packages/apollo-link-http/src/__tests__/httpLink.ts
@@ -2,6 +2,7 @@ import { Observable, ApolloLink, execute } from 'apollo-link';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 import * as fetchMock from 'fetch-mock';
+import objectToQuery from 'object-to-querystring';
 
 import { HttpLink, createHttpLink } from '../httpLink';
 
@@ -398,41 +399,17 @@ describe('HttpLink', () => {
   });
   it('allows uri to be a function', done => {
     const variables = { params: 'stub' };
-    const uriFunc = jest.fn().mockReturnValueOnce('dataFunc');
-    const link = createHttpLink({ uri: uriFunc });
+    const customFetch = (uri, options) => {
+      const { operationName } = JSON.parse(options.body);
+      expect(operationName).toBe('SampleQuery');
+      return fetch('dataFunc', options);
+    };
+
+    const link = createHttpLink({ fetch: customFetch });
 
     execute(link, { query: sampleQuery, variables }).subscribe(result => {
       const uri = fetchMock.lastUrl();
       expect(fetchMock.lastUrl()).toBe('dataFunc');
-      // Simple check if uri function was called with operation
-      expect(uriFunc.mock.calls[0][0]).toHaveProperty(
-        'operationName',
-        'SampleQuery',
-      );
-      done();
-    });
-  });
-  it('allows context uri to be a function', done => {
-    const variables = { params: 'stub' };
-    const contextUriFunc = jest.fn().mockReturnValueOnce('dataFunc');
-    const middleware = new ApolloLink((operation, forward) => {
-      operation.setContext({
-        uri: contextUriFunc,
-      });
-      return forward(operation);
-    });
-    const link = middleware.concat(
-      createHttpLink({ uri: 'data', credentials: 'error' }),
-    );
-
-    execute(link, { query: sampleQuery, variables }).subscribe(result => {
-      const uri = fetchMock.lastUrl();
-      expect(uri).toBe('dataFunc');
-      // Simple check if uri function was called with operation
-      expect(contextUriFunc.mock.calls[0][0]).toHaveProperty(
-        'operationName',
-        'SampleQuery',
-      );
       done();
     });
   });
@@ -451,15 +428,27 @@ describe('HttpLink', () => {
       done();
     });
   });
-  it('supports using a GET request', done => {
+  fit('supports using a GET request', done => {
     const variables = { params: 'stub' };
+
+    let requestedString;
+    const customFetch = (uri, options) => {
+      const { body, ...newOptions } = options;
+      const queryString = objectToQuery(JSON.parse(body));
+      requestedString = uri + queryString;
+      return fetch(requestedString, newOptions);
+    };
     const link = createHttpLink({
       uri: 'data',
       fetchOptions: { method: 'GET' },
+      fetch: customFetch,
     });
 
     execute(link, { query: sampleQuery, variables }).subscribe(result => {
-      const method = fetchMock.lastCall()[1].method;
+      const [uri, options] = fetchMock.lastCall();
+      const { method, body, ...rest } = options;
+      expect(body).toBeUndefined();
+
       expect(method).toBe('GET');
       done();
     });

--- a/packages/apollo-link-http/src/httpLink.ts
+++ b/packages/apollo-link-http/src/httpLink.ts
@@ -73,14 +73,9 @@ const parseAndCheckResponse = request => (response: Response) => {
 };
 
 const checkFetcher = (fetcher: ApolloFetch | GlobalFetch['fetch']) => {
-  if (
-    (fetcher as ApolloFetch).use &&
-    (fetcher as ApolloFetch).useAfter &&
-    (fetcher as ApolloFetch).batchUse &&
-    (fetcher as ApolloFetch).batchUseAfter
-  ) {
+  if ((fetcher as ApolloFetch).use) {
     throw new Error(`
-      It looks like you're using apollo-fetch! Apollo Link now uses the native fetch
+      It looks like you're using apollo-fetch! Apollo Link now uses native fetch
       implementation, so apollo-fetch is not needed. If you want to use your existing
       apollo-fetch middleware, please check this guide to upgrade:
         https://github.com/apollographql/apollo-link/blob/master/docs/implementation.md
@@ -209,17 +204,7 @@ export const createHttpLink = (
         const { controller, signal } = createSignalIfSupported();
         if (controller) fetcherOptions.signal = signal;
 
-        let fetchUri = uri;
-        if (contextURI) {
-          fetchUri =
-            typeof contextURI === 'function'
-              ? contextURI(operation)
-              : contextURI;
-        } else if (typeof uri === 'function') {
-          fetchUri = uri(operation);
-        }
-
-        fetcher(fetchUri as string, fetcherOptions)
+        fetcher(contextURI || uri, fetcherOptions)
           // attach the raw response to the context for usage
           .then(response => {
             operation.setContext({ response });


### PR DESCRIPTION
This removes some unreleased code that wasn't actually necessary because of a pattern I missed. Still need to document in the readme but in short, you can use `fetch` as one of the options for creating the link that allows for a lot of custom features including GET requests using query strings and custom uri's generated from operation information.