### PR TITLE
fix setContext usage not merging

### DIFF
--- a/packages/apollo-link/CHANGELOG.md
+++ b/packages/apollo-link/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ### vNEXT
 
-# 1.0.4
+# 1.0.5
 - fix bug where context wasn't merged when setting it
+
+# 1.0.4
+- export link util helpers
 
 # 1.0.3
 - removed requiring query on initial execution check

--- a/packages/apollo-link/CHANGELOG.md
+++ b/packages/apollo-link/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### vNEXT
 
+# 1.0.4
+- fix bug where context wasn't merged when setting it
+
 # 1.0.3
 - removed requiring query on initial execution check
 - moved to move efficent rollup build

--- a/packages/apollo-link/package.json
+++ b/packages/apollo-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-link",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Flexible, lightweight transport layer for GraphQL",
   "author": "Evans Hauser <evanshauser@gmail.com>",
   "contributors": [

--- a/packages/apollo-link/src/linkUtils.ts
+++ b/packages/apollo-link/src/linkUtils.ts
@@ -93,9 +93,9 @@ export function createOperation(
   let context = { ...starting };
   const setContext = next => {
     if (typeof next === 'function') {
-      context = next(context);
+      context = { ...context, ...next(context) };
     } else {
-      context = { ...next };
+      context = { ...context, ...next };
     }
   };
   const getContext = () => ({ ...context });


### PR DESCRIPTION
This fixes the base link class to match the expected semantics around context merging and adds test for it!