### PR TITLE
Set up named interfaces for all link's options objects

### DIFF
--- a/packages/apollo-link-batch-http/src/batchHttpLink.ts
+++ b/packages/apollo-link-batch-http/src/batchHttpLink.ts
@@ -4,6 +4,39 @@ import { BatchLink } from 'apollo-link-batch';
 
 import { print } from 'graphql/language/printer';
 
+export namespace BatchHttpLink {
+  /**
+   * Note: This package will be updated to remove the dependency on apollo-fetch an use the same options / API as the http-link.
+   */
+  export interface Options {
+    /**
+     * The URI to use when fetching operations.
+     *
+     * Defaults to '/graphql'.
+     */
+    uri?: string;
+
+    /**
+     * The maximum number of operations to include in one fetch.
+     *
+     * Defaults to 10.
+     */
+    batchMax?: number;
+
+    /**
+     * The interval at which to batch, in milliseconds.
+     *
+     * Defaults to 10.
+     */
+    batchInterval?: number;
+
+    /**
+     * An instance of ApolloFetch to use when making requests.
+     */
+    fetch?: ApolloFetch;
+  }
+}
+
 /** Transforms Operation for into HTTP results.
  * context can include the headers property, which will be passed to the fetch function
  */
@@ -14,12 +47,7 @@ export class BatchHttpLink extends ApolloLink {
   private batchMax: number;
   private batcher: ApolloLink;
 
-  constructor(fetchParams?: {
-    uri?: string;
-    batchInterval?: number;
-    batchMax?: number;
-    fetch?: ApolloFetch;
-  }) {
+  constructor(fetchParams?: BatchHttpLink.Options) {
     super();
 
     this.batchInterval = (fetchParams && fetchParams.batchInterval) || 10;

--- a/packages/apollo-link-batch/src/batchLink.ts
+++ b/packages/apollo-link-batch/src/batchLink.ts
@@ -9,16 +9,35 @@ import { OperationBatcher, BatchHandler } from './batching';
 
 export { OperationBatcher, BatchableRequest, BatchHandler } from './batching';
 
+export namespace BatchLink {
+  export interface Options {
+    /**
+     * The interval at which to batch, in milliseconds.
+     *
+     * Defaults to 10.
+     */
+    batchInterval?: number;
+
+    /**
+     * The maximum number of operations to include in one fetch.
+     *
+     * Defaults to 0 (infinite operations within the interval).
+     */
+    batchMax?: number;
+
+    /**
+     * The handler that should execute a batch of operations.
+     */
+    batchHandler: BatchHandler;
+  }
+}
+
 export class BatchLink extends ApolloLink {
   private batchInterval: number;
   private batchMax: number;
   private batcher: OperationBatcher;
 
-  constructor(fetchParams: {
-    batchInterval?: number;
-    batchMax?: number;
-    batchHandler: BatchHandler;
-  }) {
+  constructor(fetchParams: BatchLink.Options) {
     super();
 
     this.batchInterval = (fetchParams && fetchParams.batchInterval) || 10;

--- a/packages/apollo-link-error/src/index.ts
+++ b/packages/apollo-link-error/src/index.ts
@@ -8,7 +8,17 @@ export interface ErrorResponse {
   operation: Operation;
 }
 
-export type ErrorHandler = (error: ErrorResponse) => void;
+export namespace ErrorLink {
+  /**
+   * Callback to be triggered when an error occurs within the link stack.
+   */
+  export interface ErrorHandler {
+    (error: ErrorResponse): void;
+  }
+}
+
+// For backwards compatibility.
+export import ErrorHandler = ErrorLink.ErrorHandler;
 
 export const onError = (errorHandler: ErrorHandler): ApolloLink => {
   return new ApolloLink((operation, forward) => {
@@ -51,7 +61,7 @@ export const onError = (errorHandler: ErrorHandler): ApolloLink => {
 
 export class ErrorLink extends ApolloLink {
   private link: ApolloLink;
-  constructor(errorHandler: ErrorHandler) {
+  constructor(errorHandler: ErrorLink.ErrorHandler) {
     super();
     this.link = onError(errorHandler);
   }

--- a/packages/apollo-link-http/src/httpLink.ts
+++ b/packages/apollo-link-http/src/httpLink.ts
@@ -4,6 +4,55 @@ import { print } from 'graphql/language/printer';
 // types
 import { ApolloFetch } from 'apollo-fetch';
 
+export namespace HttpLink {
+  /**
+   * A function that generates the URI to use when fetching a particular operation.
+   */
+  export interface UriFunction {
+    (operation: Operation): string;
+  }
+
+  export interface Options {
+    /**
+     * The URI to use when fetching operations.
+     *
+     * Defaults to '/graphql'.
+     */
+    uri?: string | UriFunction;
+
+    /**
+     * Passes the extensions field to your graphql server.
+     *
+     * Defaults to false.
+     */
+    includeExtensions?: boolean;
+
+    /**
+     * A `fetch`-compatible API to use when making requests.
+     */
+    fetch?: GlobalFetch['fetch'];
+
+    /**
+     * An object representing values to be sent as headers on the request.
+     */
+    headers?: any;
+
+    /**
+     * The credentials policy you want to use for the fetch call.
+     */
+    credentials?: string;
+
+    /**
+     * Any overrides of the fetch options argument to pass to the fetch call.
+     */
+    fetchOptions?: any;
+  }
+}
+
+// For backwards compatibility.
+export import FetchOptions = HttpLink.Options;
+export import UriFunction = HttpLink.UriFunction;
+
 // XXX replace with actual typings when available
 declare var AbortController: any;
 
@@ -110,19 +159,6 @@ const createSignalIfSupported = () => {
   return { controller, signal };
 };
 
-export interface UriFunction {
-  (operation: Operation): string;
-}
-
-export interface FetchOptions {
-  uri?: string | UriFunction;
-  fetch?: GlobalFetch['fetch'];
-  includeExtensions?: boolean;
-  credentials?: string;
-  headers?: any;
-  fetchOptions?: any;
-}
-
 const defaultHttpOptions = {
   includeQuery: true,
   includeExtensions: false,
@@ -134,7 +170,7 @@ export const createHttpLink = (
     fetch: fetcher,
     includeExtensions,
     ...requestOptions,
-  }: FetchOptions = {},
+  }: HttpLink.Options = {},
 ) => {
   // dev warnings to ensure fetch is present
   warnIfNoFetch(fetcher);
@@ -234,7 +270,7 @@ export const createHttpLink = (
 
 export class HttpLink extends ApolloLink {
   public requester: RequestHandler;
-  constructor(opts?: FetchOptions) {
+  constructor(opts?: HttpLink.Options) {
     super(createHttpLink(opts).request);
   }
 }

--- a/packages/apollo-link-polling/src/pollingLink.ts
+++ b/packages/apollo-link-polling/src/pollingLink.ts
@@ -6,12 +6,19 @@ import {
   Observable,
 } from 'apollo-link';
 
+export namespace PollingLink {
+  /**
+   * Frequency (in milliseconds) that an operation should be polled on.
+   */
+  export type PollInterval = (operation: Operation) => number | null;
+}
+
 export class PollingLink extends ApolloLink {
-  private pollInterval: (operation: Operation) => number | null;
+  private pollInterval: PollingLink.PollInterval;
   private timer;
   private subscription: ZenObservable.Subscription;
 
-  constructor(pollInterval: (operation: Operation) => number | null) {
+  constructor(pollInterval: PollingLink.PollInterval) {
     super();
     this.pollInterval = pollInterval;
   }

--- a/packages/apollo-link-polling/src/pollingLink.ts
+++ b/packages/apollo-link-polling/src/pollingLink.ts
@@ -10,7 +10,9 @@ export namespace PollingLink {
   /**
    * Frequency (in milliseconds) that an operation should be polled on.
    */
-  export type PollInterval = (operation: Operation) => number | null;
+  export interface PollInterval {
+    (operation: Operation): number | null;
+  }
 }
 
 export class PollingLink extends ApolloLink {

--- a/packages/apollo-link-retry/src/retryLink.ts
+++ b/packages/apollo-link-retry/src/retryLink.ts
@@ -15,7 +15,7 @@ export namespace RetryLink {
   export type ParamFnOrNumber = (operation: Operation) => number | number;
   export type IntervalFn = (delay: number, count: number) => number;
 
-  export interface Configuration {
+  export interface Options {
     /**
      * The max number of times to try a single operation before giving up.
      *
@@ -56,7 +56,7 @@ export class RetryLink extends ApolloLink {
   private timers = {};
   private counts: { [key: string]: number } = {};
 
-  constructor(params?: RetryLink.Configuration) {
+  constructor(params?: RetryLink.Options) {
     super();
     this.max = operationFnOrNumber((params && params.max) || 10);
     this.delay = operationFnOrNumber((params && params.delay) || 300);

--- a/packages/apollo-link-retry/src/retryLink.ts
+++ b/packages/apollo-link-retry/src/retryLink.ts
@@ -11,21 +11,52 @@ const operationFnOrNumber = prop =>
 
 const defaultInterval = delay => delay;
 
-export type ParamFnOrNumber = (operation: Operation) => number | number;
+export namespace RetryLink {
+  export type ParamFnOrNumber = (operation: Operation) => number | number;
+  export type IntervalFn = (delay: number, count: number) => number;
+
+  export interface Configuration {
+    /**
+     * The max number of times to try a single operation before giving up.
+     *
+     * Can be a function that determines the number of attempts for a particular operation.
+     *
+     * Defaults to 10.
+     */
+    max?: ParamFnOrNumber;
+
+    /**
+     * Number of milliseconds to wait after a failed attempt before retrying.
+     *
+     * Can be a function that determines the delay for a particular operation.
+     *
+     * Defaults to 300.
+     */
+    delay?: ParamFnOrNumber;
+
+    /**
+     * A function that returns the actual milliseconds to wait after a failed attempt before retrying.
+     *
+     * Its first argument is the value of `delay` for that operation.
+     *
+     * Defaults to just passing the delay through.
+     */
+    interval?: IntervalFn;
+  }
+}
+
+// For backwards compatibility.
+export import ParamFnOrNumber = RetryLink.ParamFnOrNumber;
 
 export class RetryLink extends ApolloLink {
-  private delay: ParamFnOrNumber;
-  private max: ParamFnOrNumber;
-  private interval: (delay: number, count: number) => number;
+  private delay: RetryLink.ParamFnOrNumber;
+  private max: RetryLink.ParamFnOrNumber;
+  private interval: RetryLink.IntervalFn;
   private subscriptions: { [key: string]: ZenObservable.Subscription } = {};
   private timers = {};
   private counts: { [key: string]: number } = {};
 
-  constructor(params?: {
-    max?: ParamFnOrNumber;
-    delay?: ParamFnOrNumber;
-    interval?: (delay: number, count: number) => number;
-  }) {
+  constructor(params?: RetryLink.Configuration) {
     super();
     this.max = operationFnOrNumber((params && params.max) || 10);
     this.delay = operationFnOrNumber((params && params.delay) || 300);

--- a/packages/apollo-link-retry/src/retryLink.ts
+++ b/packages/apollo-link-retry/src/retryLink.ts
@@ -12,8 +12,13 @@ const operationFnOrNumber = prop =>
 const defaultInterval = delay => delay;
 
 export namespace RetryLink {
-  export type ParamFnOrNumber = (operation: Operation) => number | number;
-  export type IntervalFn = (delay: number, count: number) => number;
+  export interface ParamFnOrNumber {
+    (operation: Operation): number | number;
+  }
+
+  export interface IntervalFn {
+    (delay: number, count: number): number;
+  }
 
   export interface Options {
     /**

--- a/packages/apollo-link-schema/src/schemaLink.ts
+++ b/packages/apollo-link-schema/src/schemaLink.ts
@@ -1,20 +1,31 @@
 import { ApolloLink, Operation, FetchResult, Observable } from 'apollo-link';
 import { execute, GraphQLSchema } from 'graphql';
 
+export namespace SchemaLink {
+  export interface Options {
+    /**
+     * The schema to generate responses from.
+     */
+    schema: GraphQLSchema;
+
+    /**
+     * The root value to use when generating responses.
+     */
+    rootValue?: any;
+
+    /**
+     * A context to provide to resolvers declared within the schema.
+     */
+    context?: any;
+  }
+}
+
 export class SchemaLink extends ApolloLink {
   public schema: GraphQLSchema;
   public rootValue: any;
   public context: any;
 
-  constructor({
-    schema,
-    rootValue,
-    context
-  }: {
-    schema: GraphQLSchema;
-    rootValue?: any;
-    context?: any;
-  }) {
+  constructor({ schema, rootValue, context }: SchemaLink.Options) {
     super();
 
     this.schema = schema;

--- a/packages/apollo-link-ws/src/webSocketLink.ts
+++ b/packages/apollo-link-ws/src/webSocketLink.ts
@@ -2,16 +2,37 @@ import { ApolloLink, Operation, FetchResult, Observable } from 'apollo-link';
 
 import { SubscriptionClient, ClientOptions } from 'subscriptions-transport-ws';
 
-export type WebSocketParams = {
-  uri: string;
-  options?: ClientOptions;
-  webSocketImpl?: any;
-};
+export namespace WebSocketLink {
+  /**
+   * Configuration to use when constructing the subscription client (subscriptions-transport-ws).
+   */
+  export interface Configuration {
+    /**
+     * The endpoint to connect to.
+     */
+    uri: string;
+
+    /**
+     * Options to pass when constructing the subscription client.
+     */
+    options?: ClientOptions;
+
+    /**
+     * A custom WebSocket implementation to use.
+     */
+    webSocketImpl?: any;
+  }
+}
+
+// For backwards compatibility.
+export import WebSocketParams = WebSocketLink.Configuration;
 
 export class WebSocketLink extends ApolloLink {
   private subscriptionClient: SubscriptionClient;
 
-  constructor(paramsOrClient: WebSocketParams | SubscriptionClient) {
+  constructor(
+    paramsOrClient: WebSocketLink.Configuration | SubscriptionClient,
+  ) {
     super();
 
     if (paramsOrClient instanceof SubscriptionClient) {


### PR DESCRIPTION
This PR sets up named interfaces for the options objects of all links (that have 'em), and
sets up a pattern where those types hang off of the link classes themselves.  It also sneaks in doc strings (copied from the docs site, for the most part).  Rationale:

* TypeScript uses the name of named interfaces when emitting errors (rather than just the
  type's shape) - this aids greatly in debugging compile-time errors.

* Hanging the types off of each link's namespace makes it convenient to access their types,
  as well as perform declaration merging if needed.

* Aids in consistency between link implementations.