### PR TITLE
Replace print with execute

### DIFF
--- a/packages/apollo-link-schema/src/schemaLink.ts
+++ b/packages/apollo-link-schema/src/schemaLink.ts
@@ -1,5 +1,5 @@
 import { ApolloLink, Operation, FetchResult, Observable } from 'apollo-link';
-import { graphql, execute, GraphQLSchema } from 'graphql';
+import { execute, GraphQLSchema } from 'graphql';
 
 export class SchemaLink extends ApolloLink {
   public schema: GraphQLSchema;

--- a/packages/apollo-link-schema/src/schemaLink.ts
+++ b/packages/apollo-link-schema/src/schemaLink.ts
@@ -1,7 +1,5 @@
 import { ApolloLink, Operation, FetchResult, Observable } from 'apollo-link';
-
-import { print } from 'graphql/language/printer';
-import { graphql, GraphQLSchema } from 'graphql';
+import { graphql, execute, GraphQLSchema } from 'graphql';
 
 export class SchemaLink extends ApolloLink {
   public schema: GraphQLSchema;
@@ -25,19 +23,14 @@ export class SchemaLink extends ApolloLink {
   }
 
   public request(operation: Operation): Observable<FetchResult> | null {
-    const request = {
-      ...operation,
-      query: print(operation.query)
-    };
-
     return new Observable<FetchResult>(observer => {
-      graphql(
+      execute(
         this.schema,
-        request.query,
+        operation.query,
         this.rootValue,
         this.context,
-        request.variables,
-        request.operationName
+        operation.variables,
+        operation.operationName
       )
         .then(data => {
           if (!observer.closed) {


### PR DESCRIPTION
There's no need to stringify the query before execution as the GraphQL executor will operate on the AST.

<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
- [ ] Add your name and email to the AUTHORS file (optional)
- [x] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
