### PR TITLE
[RetryLink] Track retries per request, rather than per operation

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     {
       "name": "apollo-link-retry",
       "path": "./packages/apollo-link-retry/lib/bundle.min.js",
-      "maxSize": "1 Kb"
+      "maxSize": "1.5 Kb"
     },
     {
       "name": "apollo-link-ws",

--- a/packages/apollo-link-retry/package.json
+++ b/packages/apollo-link-retry/package.json
@@ -56,7 +56,8 @@
     "ts-jest": "21.2.4",
     "tslint": "5.8.0",
     "typescript": "2.6.2",
-    "uglify-js": "3.2.1"
+    "uglify-js": "3.2.1",
+    "wait-for-observables": "^1.0.3"
   },
   "jest": {
     "transform": {

--- a/packages/apollo-link-retry/package.json
+++ b/packages/apollo-link-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-link-retry",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Retry Apollo Link for GraphQL Network Stack",
   "author": "Evans Hauser <evanshauser@gmail.com>",
   "contributors": [

--- a/packages/apollo-link-retry/src/__tests__/retryLink.ts
+++ b/packages/apollo-link-retry/src/__tests__/retryLink.ts
@@ -102,18 +102,15 @@ describe('RetryLink', () => {
   it('retries independently for concurrent requests', async () => {
     const retry = new RetryLink({ delay: 1, max: 5 });
     const data = { data: { hello: 'world' } };
-    const stub = jest.fn();
-    stub.mockReturnValueOnce(new Observable(o => o.error(standardError)));
-    stub.mockReturnValueOnce(new Observable(o => o.error(standardError)));
-    stub.mockReturnValueOnce(Observable.of(data));
+    const stub = jest.fn(() => new Observable(o => o.error(standardError)));
     const link = ApolloLink.from([retry, stub]);
 
     const [result1, result2] = await waitFor(
       execute(link, { query }),
       execute(link, { query }),
     );
-    expect(result1.values).toEqual([data]);
-    expect(result2.values).toEqual([data]);
-    expect(stub).toHaveBeenCalledTimes(6);
+    expect(result1.error).toEqual(standardError);
+    expect(result2.error).toEqual(standardError);
+    expect(stub).toHaveBeenCalledTimes(10);
   });
 });

--- a/packages/apollo-link-retry/src/__tests__/retryLink.ts
+++ b/packages/apollo-link-retry/src/__tests__/retryLink.ts
@@ -11,15 +11,15 @@ const query = gql`
   }
 `;
 
+const error = new Error('I never work');
+
 describe('RetryLink', () => {
-  it('should fail with unreachable endpoint', done => {
+  it('fails for unreachable endpoints', done => {
     const max = 10;
     const retry = new RetryLink({ delay: 1, max });
-    const error = new Error('I never work');
     const stub = jest.fn(() => {
       return new Observable(observer => observer.error(error));
     });
-
     const link = ApolloLink.from([retry, stub]);
 
     execute(link, { query }).subscribe(
@@ -37,7 +37,7 @@ describe('RetryLink', () => {
     );
   });
 
-  it('should return data from the underlying link on a successful operation', done => {
+  it('returns data from the underlying link on a successful operation', done => {
     const retry = new RetryLink();
     const data = <FetchResult>{
       data: {
@@ -46,7 +46,6 @@ describe('RetryLink', () => {
     };
     const stub = jest.fn();
     stub.mockReturnValue(Observable.of(data));
-
     const link = ApolloLink.from([retry, stub]);
 
     execute(link, { query }).subscribe(
@@ -61,9 +60,8 @@ describe('RetryLink', () => {
     );
   });
 
-  it('should return data from the underlying link on a successful retry', done => {
+  it('returns data from the underlying link on a successful retry', done => {
     const retry = new RetryLink({ delay: 1, max: 2 });
-    const error = new Error('I never work');
     const data = <FetchResult>{
       data: {
         hello: 'world',

--- a/packages/apollo-link-retry/src/retryLink.ts
+++ b/packages/apollo-link-retry/src/retryLink.ts
@@ -12,9 +12,7 @@ const operationFnOrNumber = prop =>
 const defaultInterval = delay => delay;
 
 export namespace RetryLink {
-  export interface ParamFnOrNumber {
-    (operation: Operation): number | number;
-  }
+  export type ParamFnOrNumber = number | ((operation: Operation) => number);
 
   export interface IntervalFn {
     (delay: number, count: number): number;

--- a/packages/apollo-link-retry/src/retryLink.ts
+++ b/packages/apollo-link-retry/src/retryLink.ts
@@ -161,12 +161,10 @@ class RetryableOperation<TValue = any> {
   };
 
   private onComplete = () => {
-    for (const observer of this.observers) {
-      try {
-        observer.complete();
-      } catch (error) {}
-    }
     this.complete = true;
+    for (const observer of this.observers) {
+      observer.complete();
+    }
   };
 
   private onError = error => {
@@ -178,10 +176,10 @@ class RetryableOperation<TValue = any> {
       return;
     }
 
+    this.error = error;
     for (const observer of this.observers) {
       observer.error(error);
     }
-    this.error = error;
   };
 
   private scheduleRetry(delay) {


### PR DESCRIPTION
This fixes several issues, and introduces new behavior:

* RetryLink now retries _per request_.  Previously it tracked retries per operation (multiple requests would contribute to the retry count)

* Fixes support for multiple subscribers

* I suspect this also handles #225