### PR TITLE
Deprecate apollo-link-local

### DIFF
--- a/docs/source/links/community.md
+++ b/docs/source/links/community.md
@@ -9,4 +9,3 @@ Thank you to our amazing community members who have created custom Apollo Links!
 - [apollo-angular-link-http](https://www.npmjs.com/package/apollo-angular-link-http) by [@kamilkisiela](https://github.com/kamilkisiela): https://www.npmjs.com/package/apollo-angular-link-http
 - [apollo-link-logger](https://github.com/blackxored/apollo-link-logger) by [@blackxored](https://github.com/blackxored): Logger for Apollo Link that uses a similar format to redux-logger. Includes performance information.
 - [apollo-link-redux](https://github.com/AdamYee/apollo-link-redux) by [@AdamYee](https://github.com/AdamYee): Dispatches apollo-client 1.0-ish Redux actions.
-- [apollo-link-local](https://github.com/imranolas/apollo-link-local) by [@imranolas](https://github.com/imranolas): An Apollo Link to execute queries against a local schema


### PR DESCRIPTION
...in favor of `apollo-link-schema`. Both packages are practically identical but as `apollo-link-schema` exists under the apollographql org it makes sense to deprecate the former 😢 

<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
- [ ] Add your name and email to the AUTHORS file (optional)
- [ ] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
