### PR TITLE
Fix typescript destructuring error in apollo-link-http

### DIFF
--- a/packages/apollo-link-http/CHANGELOG.md
+++ b/packages/apollo-link-http/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Fix typescript bug with destructuring of parameter in createHttpLink (#189)
 
 ### 1.3.0
 - changed to initially parsing response as text to improve error handling

--- a/packages/apollo-link-http/src/httpLink.ts
+++ b/packages/apollo-link-http/src/httpLink.ts
@@ -164,14 +164,13 @@ const defaultHttpOptions = {
   includeExtensions: false,
 };
 
-export const createHttpLink = (
-  {
+export const createHttpLink = (linkOptions: HttpLink.Options = {}) => {
+  let {
     uri,
     fetch: fetcher,
     includeExtensions,
-    ...requestOptions,
-  }: HttpLink.Options = {},
-) => {
+    ...requestOptions
+  } = linkOptions;
   // dev warnings to ensure fetch is present
   warnIfNoFetch(fetcher);
   if (fetcher) checkFetcher(fetcher);


### PR DESCRIPTION
This PR fixes typescript error in `apollo-link-http`:
```
error TS2459: Type 'FetchOptions | undefined' has no property 'uri' and no string index signature.
```
The solution was suggested in #189 