### PR TITLE
RetryLink 2.0 - exponential backoff, and split options into delay & retry strategies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     {
       "name": "apollo-link-retry",
       "path": "./packages/apollo-link-retry/lib/bundle.min.js",
-      "maxSize": "1.5 Kb"
+      "maxSize": "2 Kb"
     },
     {
       "name": "apollo-link-ws",

--- a/packages/apollo-link-retry/README.md
+++ b/packages/apollo-link-retry/README.md
@@ -3,43 +3,59 @@ title: Retry Link
 ---
 
 ## Purpose
-An Apollo Link to allow multiple attempts when an operation has failed. One such use case is to try a request while a network connection is offline and retry until it comes back online. You can configure a RetryLink to vary the number of times it retries and how long it waits between retries through its configuration.
+
+An Apollo Link to allow multiple attempts when an operation has failed, due to network or server errors. `RetryLink` provides exponential backoff, and jitters delays between attempts by default. It does not (currently) support retries for GraphQL errors.
+
+One such use case is to try a request while a network connection is offline and retry until it comes back online.
 
 ## Installation
 
-`npm install apollo-link-retry --save`
+```sh
+npm install apollo-link-retry --save
+```
 
 ## Usage
-```js
+
+```ts
 import { RetryLink } from "apollo-link-retry";
 
 const link = new RetryLink();
 ```
 
 ## Options
-Retry Link takes an object with three options on it to customize the behavior of the link.
 
-Retry Link retries on network errors only, not on GraphQL errors.
+The standard retry strategy provides exponential backoff with jittering, and takes the following options:
 
-The default delay algorithm is to wait `delay` ms between each retry. You can customize the algorithm (eg, replacing with exponential backoff) with the `interval` option. The possible values for the configuration object are as follow:
-- `max`: a number or function matching (Operation => number) to determine the max number of times to try a single operation before giving up. It defaults to 10
-- `delay`: a number or function matching (Operation => number) to input to the interval function below: Defaults to 300 ms
-- `interval`: a function matching (delay: number, count: number) => number which is the amount of time (in ms) to wait before the next attempt; count is the number of requests previously tried
+- `initialDelay`: The number of milliseconds to wait before attempting the first retry, with a default of `300`.
 
-```js
+- `maxDelay`: The maximum number of milliseconds that the link should wait for any retry, with a default of `Infinity`.
+
+- `maxTries`: The max number of times to try a single operation before giving up, with a default of `5`.
+
+- `jitter`: Whether delays between attempts should be randomized, with a default of `true`.
+
+- `retryIf`: A predicate function that can determine whether a particular response should be retried.  By default, any response with an `error` is retried.
+
+### On Exponential Backoff & Jitter
+
+Starting with `initialDelay`, the delay of each subsequent retry is increased exponentially (by a power of 2).  For example, if `initialDelay` is 100, additional retries will occur after delays of 200, 400, 800, etc.
+
+Additionally, with `jitter` enabled, delays are randomized anywhere between 0ms (instant), and 2x the configured delay so that, on average, they should occur at the same intervals.
+
+These two features combined help alleviate [the thundering herd problem](https://en.wikipedia.org/wiki/Thundering_herd_problem), by distributing load during major outages.
+
+### Advanced Mode
+
+Instead of the options object, you may pass a function that provides full control over whether and how a particular error response should be retried.
+
+```ts
 import { RetryLink } from "apollo-link-retry";
 
-const max = (operation) => operation.getContext().max;
-const delay = 5000;
-const interval = (delay, count) => {
-  if (count > 5) return 10000;
-  return delay;
-}
-
-const link = new RetryLink({
-  max,
-  delay,
-  interval
+const link = new RetryLink((count, operation, error) => {
+  // Return false if you want to stop retrying this operation.
+  //
+  // Or, alternatively, return the number of milliseconds that it should be
+  // retried after.
 });
 ```
 

--- a/packages/apollo-link-retry/package.json
+++ b/packages/apollo-link-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-link-retry",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Retry Apollo Link for GraphQL Network Stack",
   "author": "Evans Hauser <evanshauser@gmail.com>",
   "contributors": [

--- a/packages/apollo-link-retry/src/__tests__/delayFunction.ts
+++ b/packages/apollo-link-retry/src/__tests__/delayFunction.ts
@@ -1,0 +1,82 @@
+import { buildDelayFunction } from '../delayFunction';
+
+describe('buildDelayFunction', () => {
+  // For easy testing of just the delay component, which is all we care about in
+  // the default implementation.
+  interface SimpleDelayFunction {
+    (count: number): number;
+  }
+
+  function delayRange(delayFunction: SimpleDelayFunction, count: number) {
+    const results = [];
+    for (let i = 1; i <= count; i++) {
+      results.push(delayFunction(i));
+    }
+    return results;
+  }
+
+  describe('without jitter', () => {
+    it('grows exponentially up to maxDelay', () => {
+      const delayFunction = buildDelayFunction({
+        jitter: false,
+        initial: 100,
+        max: 1000,
+      }) as SimpleDelayFunction;
+
+      expect(delayRange(delayFunction, 6)).toEqual([
+        100,
+        200,
+        400,
+        800,
+        1000,
+        1000,
+      ]);
+    });
+  });
+
+  describe('with jitter', () => {
+    let mockRandom, origRandom;
+    beforeEach(() => {
+      mockRandom = jest.fn();
+      origRandom = Math.random;
+      Math.random = mockRandom;
+    });
+
+    afterEach(() => {
+      Math.random = origRandom;
+    });
+
+    it('jitters, on average, exponentially up to maxDelay', () => {
+      const delayFunction = buildDelayFunction({
+        jitter: true,
+        initial: 100,
+        max: 1000,
+      }) as SimpleDelayFunction;
+
+      mockRandom.mockReturnValue(0.5);
+      expect(delayRange(delayFunction, 5)).toEqual([100, 200, 400, 500, 500]);
+    });
+
+    it('can have instant retries as the low end of the jitter range', () => {
+      const delayFunction = buildDelayFunction({
+        jitter: true,
+        initial: 100,
+        max: 1000,
+      }) as SimpleDelayFunction;
+
+      mockRandom.mockReturnValue(0);
+      expect(delayRange(delayFunction, 5)).toEqual([0, 0, 0, 0, 0]);
+    });
+
+    it('uses double the calculated delay as the high end of the jitter range, up to maxDelay', () => {
+      const delayFunction = buildDelayFunction({
+        jitter: true,
+        initial: 100,
+        max: 1000,
+      }) as SimpleDelayFunction;
+
+      mockRandom.mockReturnValue(1);
+      expect(delayRange(delayFunction, 5)).toEqual([200, 400, 800, 1000, 1000]);
+    });
+  });
+});

--- a/packages/apollo-link-retry/src/__tests__/retryFunction.ts
+++ b/packages/apollo-link-retry/src/__tests__/retryFunction.ts
@@ -1,0 +1,26 @@
+import { buildRetryFunction, RetryFunction } from '../retryFunction';
+
+describe('buildRetryFunction', () => {
+  it('stops after hitting maxTries', () => {
+    const retryFunction = buildRetryFunction({ max: 3 });
+
+    expect(retryFunction(2, null, {})).toEqual(true);
+    expect(retryFunction(3, null, {})).toEqual(false);
+    expect(retryFunction(4, null, {})).toEqual(false);
+  });
+
+  it('skips retries if there was no error, by default', () => {
+    const retryFunction = buildRetryFunction();
+
+    expect(retryFunction(1, null, undefined)).toEqual(false);
+    expect(retryFunction(1, null, {})).toEqual(true);
+  });
+
+  it('supports custom predicates, but only if max is not exceeded', () => {
+    const stub = jest.fn(() => true);
+    const retryFunction = buildRetryFunction({ max: 3, retryIf: stub });
+
+    expect(retryFunction(2, null, null)).toEqual(true);
+    expect(retryFunction(3, null, null)).toEqual(false);
+  });
+});

--- a/packages/apollo-link-retry/src/__tests__/retryLink.ts
+++ b/packages/apollo-link-retry/src/__tests__/retryLink.ts
@@ -16,14 +16,14 @@ const standardError = new Error('I never work');
 
 describe('RetryLink', () => {
   it('fails for unreachable endpoints', async () => {
-    const max = 10;
-    const retry = new RetryLink({ delay: 1, max });
+    const maxTries = 10;
+    const retry = new RetryLink({ initialDelay: 1, maxTries });
     const stub = jest.fn(() => new Observable(o => o.error(standardError)));
     const link = ApolloLink.from([retry, stub]);
 
     const [{ error }] = await waitFor(execute(link, { query }));
     expect(error).toEqual(standardError);
-    expect(stub).toHaveBeenCalledTimes(max);
+    expect(stub).toHaveBeenCalledTimes(maxTries);
   });
 
   it('returns data from the underlying link on a successful operation', async () => {
@@ -38,7 +38,7 @@ describe('RetryLink', () => {
   });
 
   it('returns data from the underlying link on a successful retry', async () => {
-    const retry = new RetryLink({ delay: 1, max: 2 });
+    const retry = new RetryLink({ initialDelay: 1, maxTries: 2 });
     const data = { data: { hello: 'world' } };
     const stub = jest.fn();
     stub.mockReturnValueOnce(new Observable(o => o.error(standardError)));
@@ -51,7 +51,7 @@ describe('RetryLink', () => {
   });
 
   it('calls unsubscribe on the appropriate downstream observable', async () => {
-    const retry = new RetryLink({ delay: 1, max: 2 });
+    const retry = new RetryLink({ initialDelay: 1, maxTries: 2 });
     const data = { data: { hello: 'world' } };
     const unsubscribeStub = jest.fn();
 
@@ -84,7 +84,7 @@ describe('RetryLink', () => {
   });
 
   it('supports multiple subscribers to the same request', async () => {
-    const retry = new RetryLink({ delay: 1, max: 5 });
+    const retry = new RetryLink({ initialDelay: 1, maxTries: 5 });
     const data = { data: { hello: 'world' } };
     const stub = jest.fn();
     stub.mockReturnValueOnce(new Observable(o => o.error(standardError)));
@@ -100,7 +100,7 @@ describe('RetryLink', () => {
   });
 
   it('retries independently for concurrent requests', async () => {
-    const retry = new RetryLink({ delay: 1, max: 5 });
+    const retry = new RetryLink({ initialDelay: 1, maxTries: 5 });
     const data = { data: { hello: 'world' } };
     const stub = jest.fn(() => new Observable(o => o.error(standardError)));
     const link = ApolloLink.from([retry, stub]);
@@ -112,5 +112,117 @@ describe('RetryLink', () => {
     expect(result1.error).toEqual(standardError);
     expect(result2.error).toEqual(standardError);
     expect(stub).toHaveBeenCalledTimes(10);
+  });
+
+  describe('buildDelayFunction', () => {
+    // For easy testing of just the delay component
+    interface SimpleDelayFunction {
+      (count: number): number;
+    }
+
+    function delayRange(delayFunction: SimpleDelayFunction, count: number) {
+      const results = [];
+      for (let i = 1; i <= count; i++) {
+        results.push(delayFunction(i));
+      }
+      return results;
+    }
+
+    it('stops after hitting maxTries', () => {
+      const delayFunction = RetryLink.buildDelayFunction({
+        maxTries: 3,
+        retryIf: () => true,
+      }) as SimpleDelayFunction;
+
+      expect(typeof delayFunction(2)).toEqual('number');
+      expect(delayFunction(3)).toEqual(false);
+      expect(delayFunction(4)).toEqual(false);
+    });
+
+    it('skips retries if there was no error, by default', () => {
+      const delayFunction = RetryLink.buildDelayFunction();
+
+      expect(delayFunction(1, {} as any, undefined)).toEqual(false);
+      expect(typeof delayFunction(1, {} as any, {})).toEqual('number');
+    });
+
+    describe('without jitter', () => {
+      it('grows exponentially up to maxDelay', () => {
+        const delayFunction = RetryLink.buildDelayFunction({
+          jitter: false,
+          initialDelay: 100,
+          maxDelay: 1000,
+          maxTries: Infinity,
+          retryIf: () => true,
+        }) as SimpleDelayFunction;
+
+        expect(delayRange(delayFunction, 6)).toEqual([
+          100,
+          200,
+          400,
+          800,
+          1000,
+          1000,
+        ]);
+      });
+    });
+
+    describe('with jitter', () => {
+      let mockRandom, origRandom;
+      beforeEach(() => {
+        mockRandom = jest.fn();
+        origRandom = Math.random;
+        Math.random = mockRandom;
+      });
+
+      afterEach(() => {
+        Math.random = origRandom;
+      });
+
+      it('jitters, on average, exponentially up to maxDelay', () => {
+        const delayFunction = RetryLink.buildDelayFunction({
+          jitter: true,
+          initialDelay: 100,
+          maxDelay: 1000,
+          maxTries: Infinity,
+          retryIf: () => true,
+        }) as SimpleDelayFunction;
+
+        mockRandom.mockReturnValue(0.5);
+        expect(delayRange(delayFunction, 5)).toEqual([100, 200, 400, 500, 500]);
+      });
+
+      it('can have instant retries as the low end of the jitter range', () => {
+        const delayFunction = RetryLink.buildDelayFunction({
+          jitter: true,
+          initialDelay: 100,
+          maxDelay: 1000,
+          maxTries: Infinity,
+          retryIf: () => true,
+        }) as SimpleDelayFunction;
+
+        mockRandom.mockReturnValue(0);
+        expect(delayRange(delayFunction, 5)).toEqual([0, 0, 0, 0, 0]);
+      });
+
+      it('uses double the calculated delay as the high end of the jitter range, up to maxDelay', () => {
+        const delayFunction = RetryLink.buildDelayFunction({
+          jitter: true,
+          initialDelay: 100,
+          maxDelay: 1000,
+          maxTries: Infinity,
+          retryIf: () => true,
+        }) as SimpleDelayFunction;
+
+        mockRandom.mockReturnValue(1);
+        expect(delayRange(delayFunction, 5)).toEqual([
+          200,
+          400,
+          800,
+          1000,
+          1000,
+        ]);
+      });
+    });
   });
 });

--- a/packages/apollo-link-retry/src/__tests__/retryLink.ts
+++ b/packages/apollo-link-retry/src/__tests__/retryLink.ts
@@ -114,6 +114,21 @@ describe('RetryLink', () => {
     expect(stub).toHaveBeenCalledTimes(10);
   });
 
+  it('supports custom delay functions', async () => {
+    const delayStub = jest.fn();
+    delayStub.mockReturnValueOnce(1);
+    delayStub.mockReturnValueOnce(1);
+    delayStub.mockReturnValueOnce(false);
+
+    const retry = new RetryLink(delayStub);
+    const linkStub = jest.fn(() => new Observable(o => o.error(standardError)));
+    const link = ApolloLink.from([retry, linkStub]);
+    const [{ error }] = await waitFor(execute(link, { query }));
+
+    expect(error).toEqual(standardError);
+    expect(delayStub).toHaveBeenCalledTimes(3);
+  });
+
   describe('buildDelayFunction', () => {
     // For easy testing of just the delay component
     interface SimpleDelayFunction {

--- a/packages/apollo-link-retry/src/delayFunction.ts
+++ b/packages/apollo-link-retry/src/delayFunction.ts
@@ -1,0 +1,68 @@
+import { Operation } from 'apollo-link';
+
+/**
+ * Advanced mode: a function that implements the strategy for calculating delays
+ * for particular responses.
+ */
+export interface DelayFunction {
+  (count: number, operation: Operation, error: any): number;
+}
+
+export interface DelayFunctionOptions {
+  /**
+   * The number of milliseconds to wait before attempting the first retry.
+   *
+   * Delays will increase exponentially for each attempt.  E.g. if this is
+   * set to 100, subsequent retries will be delayed by 200, 400, 800, etc,
+   * until they reach maxDelay.
+   *
+   * Note that if jittering is enabled, this is the _average_ delay.
+   *
+   * Defaults to 300.
+   */
+  initial?: number;
+
+  /**
+   * The maximum number of milliseconds that the link should wait for any
+   * retry.
+   *
+   * Defaults to Infinity.
+   */
+  max?: number;
+
+  /**
+   * Whether delays between attempts should be randomized.
+   *
+   * This helps avoid thundering herd type situations by better distributing
+   * load during major outages.
+   *
+   * Defaults to true.
+   */
+  jitter?: boolean;
+}
+
+export function buildDelayFunction(
+  { initial = 300, max = Infinity, jitter = true }: DelayFunctionOptions = {},
+): DelayFunction {
+  let baseDelay;
+  if (jitter) {
+    // If we're jittering, baseDelay is half of the maximum delay for that
+    // attempt (and is, on average, the delay we will encounter).
+    baseDelay = initial;
+  } else {
+    // If we're not jittering, adjust baseDelay so that the first attempt
+    // lines up with initialDelay, for everyone's sanity.
+    baseDelay = initial / 2;
+  }
+
+  return function delayFunction(count: number) {
+    let delay = Math.min(max, baseDelay * 2 ** count);
+    if (jitter) {
+      // We opt for a full jitter approach for a mostly uniform distribution,
+      // but bound it within initialDelay and delay for everyone's sanity.
+      delay = Math.random() * delay;
+    }
+
+    return delay;
+  };
+}

--- a/packages/apollo-link-retry/src/retryFunction.ts
+++ b/packages/apollo-link-retry/src/retryFunction.ts
@@ -1,0 +1,40 @@
+import { Operation } from 'apollo-link';
+
+/**
+ * Advanced mode: a function that determines both whether a particular
+ * response should be retried.
+ */
+export interface RetryFunction {
+  (count: number, operation: Operation, error: any): boolean;
+}
+
+export interface RetryFunctionOptions {
+  /**
+   * The max number of times to try a single operation before giving up.
+   *
+   * Note that this INCLUDES the initial request as part of the count.
+   * E.g. maxTries of 1 indicates no retrying should occur.
+   *
+   * Defaults to 5.  Pass Infinity for infinite retries.
+   */
+  max?: number;
+
+  /**
+   * Predicate function that determines whether a particular error should
+   * trigger a retry.
+   *
+   * For example, you may want to not retry 4xx class HTTP errors.
+   *
+   * By default, all errors are retried.
+   */
+  retryIf?: (error: any) => boolean;
+}
+
+export function buildRetryFunction(
+  { max = 5, retryIf }: RetryFunctionOptions = {},
+): RetryFunction {
+  return function retryFunction(count, operation, error) {
+    if (count >= max) return false;
+    return retryIf ? retryIf(error) : !!error;
+  };
+}

--- a/packages/apollo-link-retry/src/retryLink.ts
+++ b/packages/apollo-link-retry/src/retryLink.ts
@@ -61,6 +61,8 @@ export namespace RetryLink {
      * Predicate function that determines whether a particular response should
      * be retried.
      *
+     * For example, you may want to not retry 4xx class HTTP errors.
+     *
      * By default, any response with an error will be retried.
      */
     retryIf?: (count: number, operation: Operation, error: any) => boolean;
@@ -219,14 +221,6 @@ export class RetryLink extends ApolloLink {
     } else {
       this.delayFunction = RetryLink.buildDelayFunction(optionsOrDelayFunction);
     }
-    // const max = operationFnOrNumber((params && params.max) || 10);
-    // const delay = operationFnOrNumber((params && params.delay) || 300);
-    // const interval = (params && params.interval) || defaultInterval;
-
-    // this.delayFunction = (operation, count) => {
-    //   if (count >= max(operation)) return false;
-    //   return interval(delay(operation), count);
-    // };
   }
 
   public request(


### PR DESCRIPTION
This introduces a refactored public interface to RetryLink, addressing several pieces of functionality:

* Resolves #301 by allowing `delay` to be configured via a single override

* Introduces exponential backoff by default, including jitter.

* Allows for conditional retry logic (say, for not retrying 4xx class errors)

---

The TL;DR of the new API is:

```ts
new RetryLink({
  delay: {
    initial: 300,
    max: Infinity,
    jitter: true,
  },
  attempts: {
    max: 5,
    retryIf: (_count, _operation, error) => !!error,
  },
});
```

(this is the default configuration - callers should override only the values they care about)