### PR TITLE
Pass operation to RetryLink's retryIf option

### DIFF
--- a/packages/apollo-link-retry/package.json
+++ b/packages/apollo-link-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-link-retry",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Retry Apollo Link for GraphQL Network Stack",
   "author": "Evans Hauser <evanshauser@gmail.com>",
   "contributors": [

--- a/packages/apollo-link-retry/src/__tests__/retryFunction.ts
+++ b/packages/apollo-link-retry/src/__tests__/retryFunction.ts
@@ -1,4 +1,5 @@
 import { buildRetryFunction, RetryFunction } from '../retryFunction';
+import { Operation } from 'apollo-link';
 
 describe('buildRetryFunction', () => {
   it('stops after hitting maxTries', () => {
@@ -22,5 +23,15 @@ describe('buildRetryFunction', () => {
 
     expect(retryFunction(2, null, null)).toEqual(true);
     expect(retryFunction(3, null, null)).toEqual(false);
+  });
+
+  it('passes the error and operation through to custom predicates', () => {
+    const stub = jest.fn(() => true);
+    const retryFunction = buildRetryFunction({ max: 3, retryIf: stub });
+
+    const operation = { operationName: 'foo' } as Operation;
+    const error = { message: 'bewm' };
+    retryFunction(1, operation, error);
+    expect(stub).toHaveBeenCalledWith(error, operation);
   });
 });

--- a/packages/apollo-link-retry/src/retryFunction.ts
+++ b/packages/apollo-link-retry/src/retryFunction.ts
@@ -27,7 +27,7 @@ export interface RetryFunctionOptions {
    *
    * By default, all errors are retried.
    */
-  retryIf?: (error: any) => boolean;
+  retryIf?: (error: any, operation: Operation) => boolean;
 }
 
 export function buildRetryFunction(
@@ -35,6 +35,6 @@ export function buildRetryFunction(
 ): RetryFunction {
   return function retryFunction(count, operation, error) {
     if (count >= max) return false;
-    return retryIf ? retryIf(error) : !!error;
+    return retryIf ? retryIf(error, operation) : !!error;
   };
 }


### PR DESCRIPTION
Sometimes it's helpful to inspect the operation to determine whether it should be retried, too.