### PR TITLE
[Link] Expose createOperation

### DIFF
--- a/packages/apollo-link/src/index.ts
+++ b/packages/apollo-link/src/index.ts
@@ -1,5 +1,5 @@
 export * from './link';
-export { makePromise, toPromise, fromPromise } from './linkUtils';
+export { createOperation, makePromise, toPromise, fromPromise } from './linkUtils';
 export * from './types';
 
 import * as Observable from 'zen-observable';


### PR DESCRIPTION
Aids links when they want to make changes to the operation and pass it downstream (rather than having them mutate it)

Specific case: a link that consumes a local `@directive`, and strips it before it hits the server