### PR TITLE
Fix apollo-link-state example

### DIFF
--- a/docs/source/links/state.md
+++ b/docs/source/links/state.md
@@ -170,13 +170,13 @@ update any components using that data in a query.
 
 ```js
 const WrappedComponent = graphql(GET_ARTICLES, {
-  props: ({ data: { networkStatus, articles } }) => {
-    if (data.loading) {
-      return { loading: data.loading };
+  props: ({ data: { loading, error, networkStatus, articles } }) => {
+    if (loading) {
+      return { loading };
     }
 
-    if (data.error) {
-      return { error: data.error };
+    if (error) {
+      return { error };
     }
 
     return {


### PR DESCRIPTION
Great work on the new docs for apollo-link-state!  Just a simple correction here: `data` is destructured, so it's not within scope.