### PR TITLE
Add rollup to watch scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Some common choices include Browserify, Webpack, and Meteor +1.3.
 
 
 ## Contributing
-Apollo Link uses Lerna to manage multiple packages. To get started contributing, run `npm run bootstrap` which will install all dependencies and connect the dependent projects with symlinks `node_modules`.
+Apollo Link uses Lerna to manage multiple packages. To get started contributing, run `npm run bootstrap` in the root of the repository, which will install all dependencies and connect the dependent projects with symlinks in `node_modules`. Then run `npm run build` to compile the typescript source. Finally for incremental compilation, use `npm run watch`.
 
 ## Documentation
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "coverage:upload": "codecov",
     "danger": "danger run --verbose",
     "predeploy": "npm run build",
-    "deploy": "lerna publish -m \"chore: Publish\" --independent"
+    "deploy": "lerna publish -m \"chore: Publish\" --independent",
+    "watch": "lerna run --parallel watch"
   },
   "bundlesize": [
     {

--- a/packages/apollo-link-batch-http/package.json
+++ b/packages/apollo-link-batch-http/package.json
@@ -38,7 +38,7 @@
     "prebuild": "npm run clean",
     "prepublishOnly": "npm run clean && npm run build",
     "test": "jest",
-    "watch": "tsc -w -p ."
+    "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
     "apollo-fetch": "^0.7.0",
@@ -60,6 +60,7 @@
     "proxyquire": "1.8.0",
     "rimraf": "2.6.1",
     "rollup": "0.52.3",
+    "rollup-watch": "^4.3.1",
     "ts-jest": "21.2.4",
     "tslint": "5.8.0",
     "typescript": "2.6.2",

--- a/packages/apollo-link-batch/package.json
+++ b/packages/apollo-link-batch/package.json
@@ -39,7 +39,7 @@
     "prebuild": "npm run clean",
     "prepublishOnly": "npm run clean && npm run build",
     "test": "jest",
-    "watch": "tsc -w -p ."
+    "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
     "apollo-link": "^1.0.7"
@@ -55,6 +55,7 @@
     "proxyquire": "1.8.0",
     "rimraf": "2.6.1",
     "rollup": "0.52.3",
+    "rollup-watch": "^4.3.1",
     "ts-jest": "21.2.4",
     "tslint": "5.8.0",
     "typescript": "2.6.2",

--- a/packages/apollo-link-context/package.json
+++ b/packages/apollo-link-context/package.json
@@ -32,7 +32,7 @@
     "prebuild": "npm run clean",
     "prepublishOnly": "npm run clean && npm run build",
     "test": "jest",
-    "watch": "tsc -w -p ."
+    "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
     "apollo-link": "^1.0.7"
@@ -46,6 +46,7 @@
     "jest": "21.2.1",
     "rimraf": "2.6.1",
     "rollup": "0.52.3",
+    "rollup-watch": "^4.3.1",
     "ts-jest": "21.2.4",
     "tslint": "5.8.0",
     "typescript": "2.6.2",

--- a/packages/apollo-link-dedup/package.json
+++ b/packages/apollo-link-dedup/package.json
@@ -38,7 +38,7 @@
     "prebuild": "npm run clean",
     "prepublishOnly": "npm run clean && npm run build",
     "test": "jest",
-    "watch": "tsc -w -p ."
+    "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
     "apollo-link": "^1.0.7"
@@ -52,6 +52,7 @@
     "jest": "21.2.1",
     "rimraf": "2.6.1",
     "rollup": "0.52.3",
+    "rollup-watch": "^4.3.1",
     "ts-jest": "21.2.4",
     "tslint": "5.8.0",
     "typescript": "2.6.2",

--- a/packages/apollo-link-error/package.json
+++ b/packages/apollo-link-error/package.json
@@ -32,7 +32,7 @@
     "prebuild": "npm run clean",
     "prepublishOnly": "npm run clean && npm run build",
     "test": "jest",
-    "watch": "tsc -w -p ."
+    "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
     "apollo-link": "^1.0.7"
@@ -46,6 +46,7 @@
     "jest": "21.2.1",
     "rimraf": "2.6.1",
     "rollup": "0.52.3",
+    "rollup-watch": "^4.3.1",
     "ts-jest": "21.2.4",
     "tslint": "5.8.0",
     "typescript": "2.6.2",

--- a/packages/apollo-link-http/package.json
+++ b/packages/apollo-link-http/package.json
@@ -39,7 +39,7 @@
     "prebuild": "npm run clean",
     "prepublishOnly": "npm run clean && npm run build",
     "test": "jest",
-    "watch": "tsc -w -p ."
+    "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
     "apollo-link": "^1.0.7"
@@ -59,6 +59,7 @@
     "object-to-querystring": "1.0.4",
     "rimraf": "2.6.1",
     "rollup": "0.52.3",
+    "rollup-watch": "^4.3.1",
     "ts-jest": "21.2.4",
     "tslint": "5.8.0",
     "typescript": "2.6.2",

--- a/packages/apollo-link-polling/package.json
+++ b/packages/apollo-link-polling/package.json
@@ -39,7 +39,7 @@
     "prebuild": "npm run clean",
     "prepublishOnly": "npm run clean && npm run build",
     "test": "jest",
-    "watch": "tsc -w -p ."
+    "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
     "@types/zen-observable": "0.5.3",
@@ -54,6 +54,7 @@
     "jest": "21.2.1",
     "rimraf": "2.6.1",
     "rollup": "0.52.3",
+    "rollup-watch": "^4.3.1",
     "ts-jest": "21.2.4",
     "tslint": "5.8.0",
     "typescript": "2.6.2",

--- a/packages/apollo-link-retry/package.json
+++ b/packages/apollo-link-retry/package.json
@@ -38,7 +38,7 @@
     "prebuild": "npm run clean",
     "prepublishOnly": "npm run clean && npm run build",
     "test": "jest",
-    "watch": "tsc -w -p ."
+    "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
     "@types/zen-observable": "0.5.3",
@@ -53,6 +53,7 @@
     "jest": "21.2.1",
     "rimraf": "2.6.1",
     "rollup": "0.52.3",
+    "rollup-watch": "^4.3.1",
     "ts-jest": "21.2.4",
     "tslint": "5.8.0",
     "typescript": "2.6.2",

--- a/packages/apollo-link-schema/package.json
+++ b/packages/apollo-link-schema/package.json
@@ -38,7 +38,7 @@
     "prebuild": "npm run clean",
     "prepublishOnly": "npm run clean && npm run build",
     "test": "jest",
-    "watch": "tsc -w -p ."
+    "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
     "apollo-link": "^1.0.7"
@@ -56,6 +56,7 @@
     "jest": "21.2.1",
     "rimraf": "2.6.1",
     "rollup": "0.52.3",
+    "rollup-watch": "^4.3.1",
     "ts-jest": "21.2.4",
     "tslint": "5.8.0",
     "typescript": "2.6.2",

--- a/packages/apollo-link-ws/package.json
+++ b/packages/apollo-link-ws/package.json
@@ -38,7 +38,7 @@
     "prebuild": "npm run clean",
     "prepublishOnly": "npm run clean && npm run build",
     "test": "jest",
-    "watch": "tsc -w -p ."
+    "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
     "apollo-link": "^1.0.7"
@@ -55,6 +55,7 @@
     "jest": "21.2.1",
     "rimraf": "2.6.1",
     "rollup": "0.52.3",
+    "rollup-watch": "^4.3.1",
     "subscriptions-transport-ws": "0.9.4",
     "ts-jest": "21.2.4",
     "tslint": "5.8.0",

--- a/packages/apollo-link/package.json
+++ b/packages/apollo-link/package.json
@@ -38,7 +38,7 @@
     "prebuild": "npm run clean",
     "prepublishOnly": "npm run clean && npm run build",
     "test": "jest",
-    "watch": "tsc -w -p ."
+    "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
     "@types/zen-observable": "0.5.3",
@@ -57,6 +57,7 @@
     "jest": "21.2.1",
     "rimraf": "2.6.1",
     "rollup": "0.52.3",
+    "rollup-watch": "^4.3.1",
     "ts-jest": "21.2.4",
     "tslint": "5.8.0",
     "typescript": "2.6.2",


### PR DESCRIPTION
This is a build tool addition to add rollup to the incremental compilation, since the links depend on the rollup output, not just the tsc result.

Run `npm run watch` in the root of the repository after an `npm run build`. The `npm run build` is necessary to ensure the earlier link dependencies exist, such as `apollo-link-core`.

FYI @jbaxleyiii @peggyrayzis