### PR TITLE
Simple grammatical error

### DIFF
--- a/docs/source/overview.md
+++ b/docs/source/overview.md
@@ -18,7 +18,7 @@ At the core of a link is the `request` method. A link's request is called every 
 
 The full description of a link's request looks like this:
 - `NextLink`: A function that takes an `Operation` and returns an Observable of an `ExecutionResult`
-- `RequestHandler`: A function which receives an `Operation` and a `NextLink` and returns and Observable of an `ExecutionResult`
+- `RequestHandler`: A function which receives an `Operation` and a `NextLink` and returns an Observable of an `ExecutionResult`
 
 As you can see from these types, the next link is a way to continue the chain of events until data is fetched from some data source (typically a server).
 


### PR DESCRIPTION
Not sure if an Observable of an Execution Result makes sense but it follows the pattern better at least. (Perhaps an Observable of a Execution Result would flow better?)

<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
- [ ] Add your name and email to the AUTHORS file (optional)
- [ ] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
