### PR TITLE
feat(apollo-link-retry): handle Promises from `retryIf` and `attempts`

### DIFF
--- a/packages/apollo-link-retry/src/retryFunction.ts
+++ b/packages/apollo-link-retry/src/retryFunction.ts
@@ -5,7 +5,7 @@ import { Operation } from 'apollo-link';
  * response should be retried.
  */
 export interface RetryFunction {
-  (count: number, operation: Operation, error: any): boolean;
+  (count: number, operation: Operation, error: any): boolean | Promise<boolean>;
 }
 
 export interface RetryFunctionOptions {
@@ -27,12 +27,13 @@ export interface RetryFunctionOptions {
    *
    * By default, all errors are retried.
    */
-  retryIf?: (error: any, operation: Operation) => boolean;
+  retryIf?: (error: any, operation: Operation) => boolean | Promise<boolean>;
 }
 
-export function buildRetryFunction(
-  { max = 5, retryIf }: RetryFunctionOptions = {},
-): RetryFunction {
+export function buildRetryFunction({
+  max = 5,
+  retryIf,
+}: RetryFunctionOptions = {}): RetryFunction {
   return function retryFunction(count, operation, error) {
     if (count >= max) return false;
     return retryIf ? retryIf(error, operation) : !!error;


### PR DESCRIPTION
This enables the consumer to perform async operations when deciding whether to retry, or even to attempt a fix before retrying.

Addresses https://github.com/apollographql/apollo-link/issues/433. This is a WIP while we nail down the API, tests will follow.

FYI @pho3nixf1re
