### PR TITLE
feat(apollo-link-retry): handle Promises from `retryIf` and `attempts`

### DIFF
--- a/packages/apollo-link-retry/src/__tests__/retryLink.ts
+++ b/packages/apollo-link-retry/src/__tests__/retryLink.ts
@@ -145,6 +145,7 @@ describe('RetryLink', () => {
     const attemptStub = jest.fn();
     attemptStub.mockReturnValueOnce(true);
     attemptStub.mockReturnValueOnce(true);
+    attemptStub.mockReturnValueOnce(Promise.resolve(true));
     attemptStub.mockReturnValueOnce(false);
 
     const retry = new RetryLink({
@@ -161,6 +162,7 @@ describe('RetryLink', () => {
       [1, operation, standardError],
       [2, operation, standardError],
       [3, operation, standardError],
+      [4, operation, standardError],
     ]);
   });
 });

--- a/packages/apollo-link-retry/src/retryFunction.ts
+++ b/packages/apollo-link-retry/src/retryFunction.ts
@@ -5,7 +5,7 @@ import { Operation } from 'apollo-link';
  * response should be retried.
  */
 export interface RetryFunction {
-  (count: number, operation: Operation, error: any): boolean;
+  (count: number, operation: Operation, error: any): boolean | Promise<boolean>;
 }
 
 export interface RetryFunctionOptions {
@@ -27,12 +27,13 @@ export interface RetryFunctionOptions {
    *
    * By default, all errors are retried.
    */
-  retryIf?: (error: any, operation: Operation) => boolean;
+  retryIf?: (error: any, operation: Operation) => boolean | Promise<boolean>;
 }
 
-export function buildRetryFunction(
-  { max = 5, retryIf }: RetryFunctionOptions = {},
-): RetryFunction {
+export function buildRetryFunction({
+  max = 5,
+  retryIf,
+}: RetryFunctionOptions = {}): RetryFunction {
   return function retryFunction(count, operation, error) {
     if (count >= max) return false;
     return retryIf ? retryIf(error, operation) : !!error;


### PR DESCRIPTION
This supersedes #435. Sorry for the duplicate PRs, I mistakenly created the other from a work account and wasn't sure whether I could sign the contributor agreement. 

> Handle Promises from `retryIf` and `attempts`.
> 
> This enables the consumer to perform async operations when deciding whether to retry, or even attempt a fix before retrying.

Addresses #433 (CC @pho3nixf1re)