### PR TITLE
Expose execute on ApolloLink as static

### DIFF
--- a/packages/apollo-link/CHANGELOG.md
+++ b/packages/apollo-link/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+- Expose `#execute` on ApolloLink as static
+
 # 1.0.7
 
 - Update to graphql@0.12

--- a/packages/apollo-link/src/__tests__/link.ts
+++ b/packages/apollo-link/src/__tests__/link.ts
@@ -427,7 +427,8 @@ describe('Link static library', () => {
         },
       };
       const chain = ApolloLink.from([new MockLink(() => Observable.of(data))]);
-      const observable = execute(chain, uniqueOperation);
+      // Smoke tests execute as a static method
+      const observable = ApolloLink.execute(chain, uniqueOperation);
       observable.subscribe({
         next: actualData => {
           expect(data).toEqual(actualData);

--- a/packages/apollo-link/src/link.ts
+++ b/packages/apollo-link/src/link.ts
@@ -97,6 +97,7 @@ export class ApolloLink {
   public static empty = empty;
   public static from = from;
   public static split = split;
+  public static execute = execute;
 
   public split(
     test: (op: Operation) => boolean,


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [ ] Add your name and email to the AUTHORS file (optional)
- [ ] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion

## Why?
Apollo link is super convenient tooling for composing any request/response cycle for GraphQL. However, with `#execute` being it's own import it forces other libraries to take on the dependency responsibility if they want to support Link. This way we can allow users to take responsibility for the dep and simply call execute on the exposed public method whenever a link is used.