### PR TITLE
Error http mixed data

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     {
       "name": "apollo-link-batch-http",
       "path": "./packages/apollo-link-batch-http/lib/bundle.min.js",
-      "maxSize": "6.7 Kb"
+      "maxSize": "6.8 Kb"
     },
     {
       "name": "apollo-link-dedup",

--- a/packages/apollo-link-http/CHANGELOG.md
+++ b/packages/apollo-link-http/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### vNEXT
 
+### 1.3.3
+- Allow graphql results to fire even if there is a network error
+
 ### 1.3.2
 
 - Update to graphql@0.12

--- a/packages/apollo-link-http/src/httpLink.ts
+++ b/packages/apollo-link-http/src/httpLink.ts
@@ -169,7 +169,7 @@ export const createHttpLink = (linkOptions: HttpLink.Options = {}) => {
     uri,
     fetch: fetcher,
     includeExtensions,
-    ...requestOptions
+    ...requestOptions,
   } = linkOptions;
   // dev warnings to ensure fetch is present
   warnIfNoFetch(fetcher);
@@ -255,6 +255,39 @@ export const createHttpLink = (linkOptions: HttpLink.Options = {}) => {
           .catch(err => {
             // fetch was cancelled so its already been cleaned up in the unsubscribe
             if (err.name === 'AbortError') return;
+            // if it is a network error, BUT there is graphql result info
+            // fire the next observer before calling error
+            // this gives apollo-client (and react-apollo) the `graphqlErrors` and `networErrors`
+            // to pass to UI
+            if (err.result && err.result.errors) {
+              // if we dont' call next, the UI can only show networkError because AC didn't
+              // get andy graphqlErrors
+              // this is graphql execution result info (i.e errors and possibly data)
+              // this is because there is no formal spec how errors should translate to
+              // http status codes. So an auth error (401) could have both data
+              // from a public field, errors from a private field, and a status of 401
+              // {
+              //  user { // this will have errors
+              //    firstName
+              //  }
+              //  products { // this is public so will have data
+              //    cost
+              //  }
+              // }
+              //
+              // the result of above *could* look like this:
+              // {
+              //   data: { products: [{ cost: "$10" }] },
+              //   errors: [{
+              //      message: 'your session has timed out',
+              //      path: []
+              //   }]
+              // }
+              // status code of above would be a 401
+              // in the UI you want to show data where you can, errors as data where you can
+              // and use correct http status codes
+              observer.next(err.result);
+            }
             observer.error(err);
           });
 


### PR DESCRIPTION
This fixes a bug reported by @wesbos where a 400 (or network error) wasn't sending data to the component that also came back from the GraphQL endpoint. Now data + errors will fire if there is a parse able result, then trigger the network error event.