### PR TITLE
spec-compliant GET support

### DIFF
--- a/packages/apollo-link-batch-http/CHANGELOG.md
+++ b/packages/apollo-link-batch-http/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### vNext
 - share logic with apollo-link-http through apollo-link-http-core [PR#364](https://github.com/apollographql/apollo-link/pull/364)
 - remove apollo-fetch [PR#364](https://github.com/apollographql/apollo-link/pull/364)
+- GET is no longer supported for batching (it never worked anyway) [PR#490](https://github.com/apollographql/apollo-link/pull/490)
 
 ### 1.0.5
 - ApolloLink upgrade

--- a/packages/apollo-link-batch-http/README.md
+++ b/packages/apollo-link-batch-http/README.md
@@ -29,7 +29,7 @@ http options follow the same structure as the
 * `credentials`: a string representing the credentials policy you want for the
   fetch call
 * `fetchOptions`: any overrides of the fetch options argument to pass to the
-  fetch call
+  fetch call. Note that you cannot use batching with the GET HTTP method.
 
 The batching options indicate how operations are batched together, the size of
 batches, and the maximum time a batch will wait before automatically being sent
@@ -89,24 +89,7 @@ The batch http link handles errors on a per batch basis with the same semantics 
 
 <h2 id="custom">Custom fetching</h2>
 
-You can use the `fetch` option when creating an http-link to do a lot of custom networking. This is useful if you want to modify the request based on the headers calculated, send the request as a 'GET' via a query string, or calculate the uri based on the operation:
-
-<h3 id="get-request">Sending a GET request</h3>
-
-```js
-const customFetch = (uri, options) => {
-  const { body, ...newOptions } = options;
-  // turn the object into a query string, try `object-to-querystring` package
-  const queryString = objectToQuery(JSON.parse(body));
-  requestedString = uri + queryString;
-  return fetch(requestedString, newOptions);
-};
-const link = createBatchHttpLink({
-  uri: "data",
-  fetchOptions: { method: "GET" },
-  fetch: customFetch
-});
-```
+You can use the `fetch` option when creating an http-link to do a lot of custom networking. This is useful if you want to modify the request based on the calculated headers or calculate the uri based on the operation:
 
 <h3 id="custom-auth">Custom auth</h3>
 
@@ -114,7 +97,7 @@ const link = createBatchHttpLink({
 const customFetch = (uri, options) => {
   const { header } = Hawk.client.header(
     "http://example.com:8000/resource/1?b=1&a=2",
-    "GET",
+    "POST",
     { credentials: credentials, ext: "some-app-data" }
   );
   options.headers.Authorization = header;

--- a/packages/apollo-link-batch-http/package.json
+++ b/packages/apollo-link-batch-http/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "apollo-link": "^1.1.0",
     "apollo-link-batch": "^1.0.5",
-    "apollo-link-http-common": "^0.1.0"
+    "apollo-link-http-common": "^0.2.0"
   },
   "peerDependencies": {
     "graphql": "^0.11.0 || ^0.12.3 || ^0.13.0"

--- a/packages/apollo-link-batch-http/src/batchHttpLink.ts
+++ b/packages/apollo-link-batch-http/src/batchHttpLink.ts
@@ -1,4 +1,10 @@
-import { ApolloLink, Operation, FetchResult, Observable } from 'apollo-link';
+import {
+  ApolloLink,
+  Operation,
+  FetchResult,
+  Observable,
+  fromError,
+} from 'apollo-link';
 import {
   serializeFetchBody,
   selectURI,
@@ -104,19 +110,15 @@ export class BatchHttpLink extends ApolloLink {
 
       // There's no spec for using GET with batches.
       if (options.method === 'GET') {
-        return new Observable<FetchResult[]>(observer => {
-          observer.error(
-            new Error('apollo-link-batch-http does not support GET requests'),
-          );
-        });
+        return fromError<FetchResult[]>(
+          new Error('apollo-link-batch-http does not support GET requests'),
+        );
       }
 
       try {
         (options as any).body = serializeFetchBody(body);
       } catch (parseError) {
-        return new Observable<FetchResult[]>(observer => {
-          observer.error(parseError);
-        });
+        return fromError<FetchResult[]>(parseError);
       }
 
       const { controller, signal } = createSignalIfSupported();

--- a/packages/apollo-link-batch-http/src/batchHttpLink.ts
+++ b/packages/apollo-link-batch-http/src/batchHttpLink.ts
@@ -102,6 +102,15 @@ export class BatchHttpLink extends ApolloLink {
       const body = optsAndBody.map(({ body }) => body);
       const options = optsAndBody[0].options;
 
+      // There's no spec for using GET with batches.
+      if (options.method === 'GET') {
+        return new Observable<FetchResult[]>(observer => {
+          observer.error(
+            new Error('apollo-link-batch-http does not support GET requests'),
+          );
+        });
+      }
+
       try {
         (options as any).body = serializeFetchBody(body);
       } catch (parseError) {

--- a/packages/apollo-link-batch-http/src/batchHttpLink.ts
+++ b/packages/apollo-link-batch-http/src/batchHttpLink.ts
@@ -6,7 +6,7 @@ import {
   fromError,
 } from 'apollo-link';
 import {
-  serializeFetchBody,
+  serializeFetchParameter,
   selectURI,
   parseAndCheckHttpResponse,
   checkFetcher,
@@ -116,7 +116,7 @@ export class BatchHttpLink extends ApolloLink {
       }
 
       try {
-        (options as any).body = serializeFetchBody(body);
+        (options as any).body = serializeFetchParameter(body, 'Payload');
       } catch (parseError) {
         return fromError<FetchResult[]>(parseError);
       }

--- a/packages/apollo-link-http-common/CHANGELOG.md
+++ b/packages/apollo-link-http-common/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change log
+
+### v0.2.0
+- rename serializeFetchBody to serializeFetchParameter and take a label argument

--- a/packages/apollo-link-http-common/package.json
+++ b/packages/apollo-link-http-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-link-http-common",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description":
     "Http utilities for Apollo Link shared across all links using http",
   "main": "./lib/bundle.umd.js",

--- a/packages/apollo-link-http-common/src/__tests__/index.ts
+++ b/packages/apollo-link-http-common/src/__tests__/index.ts
@@ -7,7 +7,7 @@ import {
   checkFetcher,
   selectHttpOptionsAndBody,
   selectURI,
-  serializeFetchBody,
+  serializeFetchParameter,
   fallbackHttpConfig,
 } from '../index';
 
@@ -191,19 +191,19 @@ describe('Common Http functions', () => {
     });
   });
 
-  describe('serializeFetchBody', () => {
+  describe('serializeFetchParameter', () => {
     it('throws a parse error on an unparsable body', () => {
       const b = {};
       const a = { b };
       (b as any).a = a;
 
-      expect(() => serializeFetchBody(b)).toThrow();
+      expect(() => serializeFetchParameter(b, 'Label')).toThrow(/Label/);
     });
 
     it('returns a correctly parsed body', () => {
       const body = { no: 'thing' };
 
-      expect(serializeFetchBody(body)).toEqual('{"no":"thing"}');
+      expect(serializeFetchParameter(body, 'Label')).toEqual('{"no":"thing"}');
     });
   });
 

--- a/packages/apollo-link-http-common/src/index.ts
+++ b/packages/apollo-link-http-common/src/index.ts
@@ -44,6 +44,14 @@ export interface UriFunction {
   (operation: Operation): string;
 }
 
+// The body of a GraphQL-over-HTTP-POST request.
+export interface Body {
+  query?: string;
+  operationName?: string;
+  variables?: Record<string, any>;
+  extensions?: Record<string, any>;
+}
+
 export interface HttpOptions {
   /**
    * The URI to use when fetching operations.
@@ -220,7 +228,7 @@ export const selectHttpOptionsAndBody = (
 
   //The body depends on the http options
   const { operationName, extensions, variables, query } = operation;
-  const body = { operationName, variables };
+  const body: Body = { operationName, variables };
 
   if (http.includeExtensions) (body as any).extensions = extensions;
 
@@ -233,18 +241,18 @@ export const selectHttpOptionsAndBody = (
   };
 };
 
-export const serializeFetchBody = body => {
-  let serializedBody;
+export const serializeFetchParameter = (p, label) => {
+  let serialized;
   try {
-    serializedBody = JSON.stringify(body);
+    serialized = JSON.stringify(p);
   } catch (e) {
     const parseError = new Error(
-      `Network request failed. Payload is not serializable: ${e.message}`,
+      `Network request failed. ${label} is not serializable: ${e.message}`,
     ) as ClientParseError;
     parseError.parseError = e;
     throw parseError;
   }
-  return serializedBody;
+  return serialized;
 };
 
 //selects "/graphql" by default

--- a/packages/apollo-link-http/CHANGELOG.md
+++ b/packages/apollo-link-http/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### vNEXT
 - move logic to apollo-link-http-core [PR#364](https://github.com/apollographql/apollo-link/pull/364)
+- follow the spec properly for GET requests [PR#490](https://github.com/apollographql/apollo-link/pull/490)
 
 ### 1.3.3
 - ApolloLink upgrade

--- a/packages/apollo-link-http/README.md
+++ b/packages/apollo-link-http/README.md
@@ -10,7 +10,7 @@ Link ecosystem and how to use this link with libraries like Apollo Client and
 graphql-tools, or as a standalone client.
 
 The http link is a terminating link that fetches GraphQL results from a GraphQL
-endpoint over an http connection. The http link support both POST and GET
+endpoint over an http connection. The http link supports both POST and GET
 requests with the ability change the http options on a per query basis. This
 can be used for authentication, persisted queries, dynamic uris, and other
 granular updates.
@@ -42,7 +42,9 @@ The HTTP Link relies on having `fetch` present in your runtime environment. If y
 
 <h2 id="context">Context</h2>
 
-The Http Link uses the `headers` field on the context to allow passing headers to the HTTP request. It also supports the `credentials` field for defining credentials policy, `uri` for changing the endpoint dynamically, and `fetchOptions` to allow generic fetch overrides (i.e. method: "GET"). These options will override the same key if passed when creating the the link.
+The Http Link uses the `headers` field on the context to allow passing headers to the HTTP request. It also supports the `credentials` field for defining credentials policy, `uri` for changing the endpoint dynamically, and `fetchOptions` to allow generic fetch overrides (i.e. `method: "GET"`). These options will override the same key if passed when creating the the link.
+
+Note that if you set `fetchOptions.method` to `GET`, the http link will follow the [standard GraphQL HTTP GET encoding](http://graphql.org/learn/serving-over-http/#get-request): the query, variables, operation name, and extensions will be passed as query parameters rather than in the HTTP request body.
 
 This link also attaches the response from the `fetch` operation on the context as `response` so you can access it from within another link.
 
@@ -146,24 +148,7 @@ All error types inherit the `name`, `message`, and nullable `stack` properties f
 
 <h2 id="custom">Custom fetching</h2>
 
-You can use the `fetch` option when creating an http-link to do a lot of custom networking. This is useful if you want to modify the request based on the headers calculated, send the request as a 'GET' via a query string, or calculate the uri based on the operation:
-
-<h3 id="get-request">Sending a GET request</h3>
-
-```js
-const customFetch = (uri, options) => {
-  const { body, ...newOptions } = options;
-  // turn the object into a query string, try `object-to-querystring` package
-  const queryString = objectToQuery(JSON.parse(body));
-  requestedString = uri + queryString;
-  return fetch(requestedString, newOptions);
-};
-const link = createHttpLink({
-  uri: "data",
-  fetchOptions: { method: "GET" },
-  fetch: customFetch
-});
-```
+You can use the `fetch` option when creating an http-link to do a lot of custom networking. This is useful if you want to modify the request based on the calculated headers  or calculate the uri based on the operation:
 
 <h3 id="custom-auth">Custom auth</h3>
 
@@ -171,7 +156,7 @@ const link = createHttpLink({
 const customFetch = (uri, options) => {
   const { header } = Hawk.client.header(
     "http://example.com:8000/resource/1?b=1&a=2",
-    "GET",
+    "POST",
     { credentials: credentials, ext: "some-app-data" }
   );
   options.headers.Authorization = header;

--- a/packages/apollo-link-http/package.json
+++ b/packages/apollo-link-http/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "apollo-link": "^1.1.0",
-    "apollo-link-http-common": "^0.1.0"
+    "apollo-link-http-common": "^0.2.0"
   },
   "peerDependencies": {
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0"

--- a/packages/apollo-link-http/src/__tests__/httpLink.ts
+++ b/packages/apollo-link-http/src/__tests__/httpLink.ts
@@ -1,6 +1,7 @@
 import { Observable, ApolloLink, execute } from 'apollo-link';
 import gql from 'graphql-tag';
 import * as fetchMock from 'fetch-mock';
+import objectToQuery from 'object-to-querystring';
 
 import { sharedHttpTest } from './sharedHttpTests';
 import { HttpLink, createHttpLink } from '../httpLink';
@@ -13,30 +14,99 @@ const sampleQuery = gql`
   }
 `;
 
+const makeCallback = (done, body) => {
+  return (...args) => {
+    try {
+      body(...args);
+      done();
+    } catch (error) {
+      done.fail(error);
+    }
+  };
+};
+
 describe('HttpLink', () => {
-  it('does not need any constructor arguments', () => {
-    expect(() => new HttpLink()).not.toThrow();
-  });
-
-  const makePromise = res =>
-    new Promise((resolve, reject) => setTimeout(() => resolve(res)));
-  const data = { data: { hello: 'world' } };
-
-  fetchMock.post('begin:data', makePromise(data));
-
-  it('constructor creates link that can call next and then complete', done => {
-    const next = jest.fn();
-    const link = new HttpLink({ uri: 'data' });
-    const observable = execute(link, {
-      query: sampleQuery,
+  describe('HttpLink-specific tests', () => {
+    it('does not need any constructor arguments', () => {
+      expect(() => new HttpLink()).not.toThrow();
     });
-    observable.subscribe({
-      next,
-      error: error => expect(false),
-      complete: () => {
-        expect(next).toHaveBeenCalledTimes(1);
-        done();
-      },
+
+    const makePromise = res =>
+      new Promise((resolve, reject) => setTimeout(() => resolve(res)));
+    const data = { data: { hello: 'world' } };
+
+    beforeEach(() => {
+      fetchMock.restore();
+      fetchMock.post('begin:data', makePromise(data));
+      fetchMock.get('begin:data', makePromise(data));
+    });
+
+    afterEach(() => {
+      fetchMock.restore();
+    });
+
+    it('constructor creates link that can call next and then complete', done => {
+      const next = jest.fn();
+      const link = new HttpLink({ uri: 'data' });
+      const observable = execute(link, {
+        query: sampleQuery,
+      });
+      observable.subscribe({
+        next,
+        error: error => expect(false),
+        complete: () => {
+          expect(next).toHaveBeenCalledTimes(1);
+          done();
+        },
+      });
+    });
+
+    it('supports using a GET request', done => {
+      const variables = { params: 'stub' };
+
+      let requestedString;
+      const customFetch = (uri, options) => {
+        const { body, ...newOptions } = options;
+        const queryString = objectToQuery(JSON.parse(body));
+        requestedString = uri + queryString;
+        return fetch(requestedString, newOptions);
+      };
+      const link = createHttpLink({
+        uri: 'data',
+        fetchOptions: { method: 'GET' },
+        fetch: customFetch,
+      });
+
+      execute(link, { query: sampleQuery, variables }).subscribe({
+        next: makeCallback(done, result => {
+          const [uri, options] = fetchMock.lastCall();
+          const { method, body, ...rest } = options;
+          expect(body).toBeUndefined();
+
+          expect(method).toBe('GET');
+        }),
+        error: error => done.fail(error),
+      });
+    });
+
+    it('supports using a GET request on the context', done => {
+      const variables = { params: 'stub' };
+      const link = createHttpLink({
+        uri: 'data',
+      });
+
+      execute(link, {
+        query: sampleQuery,
+        variables,
+        context: {
+          fetchOptions: { method: 'GET' },
+        },
+      }).subscribe(
+        makeCallback(done, result => {
+          const method = fetchMock.lastCall()[1].method;
+          expect(method).toBe('GET');
+        }),
+      );
     });
   });
 

--- a/packages/apollo-link-http/src/__tests__/sharedHttpTests.ts
+++ b/packages/apollo-link-http/src/__tests__/sharedHttpTests.ts
@@ -2,7 +2,6 @@ import { Observable, ApolloLink, execute } from 'apollo-link';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
 import * as fetchMock from 'fetch-mock';
-import objectToQuery from 'object-to-querystring';
 
 const sampleQuery = gql`
   query SampleQuery {
@@ -497,53 +496,6 @@ export const sharedHttpTest = (
           expect(signal).toBe('foo');
           expect(mode).toBe('no-cors');
           expect(headers['content-type']).toBe('application/json');
-        }),
-      );
-    });
-
-    it('supports using a GET request', done => {
-      const variables = { params: 'stub' };
-
-      let requestedString;
-      const customFetch = (uri, options) => {
-        const { body, ...newOptions } = options;
-        const queryString = objectToQuery(convertBatchedBody(body));
-        requestedString = uri + queryString;
-        return fetch(requestedString, newOptions);
-      };
-      const link = createLink({
-        uri: 'data',
-        fetchOptions: { method: 'GET' },
-        fetch: customFetch,
-      });
-
-      execute(link, { query: sampleQuery, variables }).subscribe(
-        makeCallback(done, result => {
-          const [uri, options] = fetchMock.lastCall();
-          const { method, body, ...rest } = options;
-          expect(body).toBeUndefined();
-
-          expect(method).toBe('GET');
-        }),
-      );
-    });
-
-    it('supports using a GET request on the context', done => {
-      const variables = { params: 'stub' };
-      const link = createLink({
-        uri: 'data',
-      });
-
-      execute(link, {
-        query: sampleQuery,
-        variables,
-        context: {
-          fetchOptions: { method: 'GET' },
-        },
-      }).subscribe(
-        makeCallback(done, result => {
-          const method = fetchMock.lastCall()[1].method;
-          expect(method).toBe('GET');
         }),
       );
     });

--- a/packages/apollo-link-http/src/httpLink.ts
+++ b/packages/apollo-link-http/src/httpLink.ts
@@ -1,6 +1,6 @@
 import { ApolloLink, Observable, RequestHandler, fromError } from 'apollo-link';
 import {
-  serializeFetchBody,
+  serializeFetchParameter,
   selectURI,
   parseAndCheckHttpResponse,
   checkFetcher,
@@ -48,7 +48,7 @@ export const createHttpLink = (linkOptions: HttpLink.Options = {}) => {
   };
 
   return new ApolloLink(operation => {
-    const chosenURI = selectURI(operation, uri);
+    let chosenURI = selectURI(operation, uri);
 
     const context = operation.getContext();
 
@@ -70,10 +70,67 @@ export const createHttpLink = (linkOptions: HttpLink.Options = {}) => {
     const { controller, signal } = createSignalIfSupported();
     if (controller) (options as any).signal = signal;
 
-    try {
-      (options as any).body = serializeFetchBody(body);
-    } catch (parseError) {
-      return fromError(parseError);
+    if (options.method === 'GET') {
+      // Implement the standard HTTP GET serialization, plus 'extensions'. Note
+      // the extra level of JSON serialization!
+      const queryParams = [];
+      const addQueryParam = (key: string, value: string) => {
+        queryParams.push(`${key}=${encodeURIComponent(value)}`);
+      };
+
+      if ('query' in body) {
+        addQueryParam('query', body.query);
+      }
+      if (body.operationName) {
+        addQueryParam('operationName', body.operationName);
+      }
+      if (body.variables) {
+        let serializedVariables;
+        try {
+          serializedVariables = serializeFetchParameter(
+            body.variables,
+            'Variables map',
+          );
+        } catch (parseError) {
+          return fromError(parseError);
+        }
+        addQueryParam('variables', serializedVariables);
+      }
+      if (body.extensions) {
+        let serializedExtensions;
+        try {
+          serializedExtensions = serializeFetchParameter(
+            body.extensions,
+            'Extensions map',
+          );
+        } catch (parseError) {
+          return fromError(parseError);
+        }
+        addQueryParam('extensions', serializedExtensions);
+      }
+
+      // Reconstruct the URI with added query params.
+      // XXX This assumes that the URI is well-formed and that it doesn't
+      //     already contain any of these query params. We could instead use the
+      //     URL API and take a polyfill (whatwg-url@6) for older browsers that
+      //     don't support URLSearchParams. Note that some browsers (and
+      //     versions of whatwg-url) support URL but not URLSearchParams!
+      let fragment = '',
+        preFragment = chosenURI;
+      const fragmentStart = chosenURI.indexOf('#');
+      if (fragmentStart !== -1) {
+        fragment = chosenURI.substr(fragmentStart);
+        preFragment = chosenURI.substr(0, fragmentStart);
+      }
+      const queryParamsPrefix = preFragment.indexOf('?') === -1 ? '?' : '&';
+      chosenURI =
+        preFragment + queryParamsPrefix + queryParams.join('&') + fragment;
+    } else {
+      try {
+        (options as any).body = serializeFetchParameter(body, 'Payload');
+      } catch (parseError) {
+        return fromError(parseError);
+      }
     }
 
     return new Observable(observer => {

--- a/packages/apollo-link-http/src/httpLink.ts
+++ b/packages/apollo-link-http/src/httpLink.ts
@@ -1,4 +1,4 @@
-import { ApolloLink, Observable, RequestHandler } from 'apollo-link';
+import { ApolloLink, Observable, RequestHandler, fromError } from 'apollo-link';
 import {
   serializeFetchBody,
   selectURI,
@@ -73,9 +73,7 @@ export const createHttpLink = (linkOptions: HttpLink.Options = {}) => {
     try {
       (options as any).body = serializeFetchBody(body);
     } catch (parseError) {
-      return new Observable(observer => {
-        observer.error(parseError);
-      });
+      return fromError(parseError);
     }
 
     return new Observable(observer => {

--- a/packages/apollo-link-retry/src/__tests__/retryLink.ts
+++ b/packages/apollo-link-retry/src/__tests__/retryLink.ts
@@ -1,5 +1,11 @@
 import gql from 'graphql-tag';
-import { execute, ApolloLink, Observable, FetchResult } from 'apollo-link';
+import {
+  execute,
+  ApolloLink,
+  Observable,
+  FetchResult,
+  fromError,
+} from 'apollo-link';
 import waitFor from 'wait-for-observables';
 
 import { RetryLink } from '../retryLink';
@@ -18,7 +24,7 @@ describe('RetryLink', () => {
   it('fails for unreachable endpoints', async () => {
     const max = 10;
     const retry = new RetryLink({ delay: { initial: 1 }, attempts: { max } });
-    const stub = jest.fn(() => new Observable(o => o.error(standardError)));
+    const stub = jest.fn(() => fromError(standardError));
     const link = ApolloLink.from([retry, stub]);
 
     const [{ error }] = await waitFor(execute(link, { query }));
@@ -44,7 +50,7 @@ describe('RetryLink', () => {
     });
     const data = { data: { hello: 'world' } };
     const stub = jest.fn();
-    stub.mockReturnValueOnce(new Observable(o => o.error(standardError)));
+    stub.mockReturnValueOnce(fromError(standardError));
     stub.mockReturnValueOnce(Observable.of(data));
     const link = ApolloLink.from([retry, stub]);
 
@@ -61,7 +67,7 @@ describe('RetryLink', () => {
     const data = { data: { hello: 'world' } };
     const unsubscribeStub = jest.fn();
 
-    const firstTry = new Observable(o => o.error(standardError));
+    const firstTry = fromError(standardError);
     // Hold the test hostage until we're hit
     let secondTry;
     const untilSecondTry = new Promise(resolve => {
@@ -96,8 +102,8 @@ describe('RetryLink', () => {
     });
     const data = { data: { hello: 'world' } };
     const stub = jest.fn();
-    stub.mockReturnValueOnce(new Observable(o => o.error(standardError)));
-    stub.mockReturnValueOnce(new Observable(o => o.error(standardError)));
+    stub.mockReturnValueOnce(fromError(standardError));
+    stub.mockReturnValueOnce(fromError(standardError));
     stub.mockReturnValueOnce(Observable.of(data));
     const link = ApolloLink.from([retry, stub]);
 
@@ -114,7 +120,7 @@ describe('RetryLink', () => {
       attempts: { max: 5 },
     });
     const data = { data: { hello: 'world' } };
-    const stub = jest.fn(() => new Observable(o => o.error(standardError)));
+    const stub = jest.fn(() => fromError(standardError));
     const link = ApolloLink.from([retry, stub]);
 
     const [result1, result2] = await waitFor(
@@ -129,7 +135,7 @@ describe('RetryLink', () => {
   it('supports custom delay functions', async () => {
     const delayStub = jest.fn(() => 1);
     const retry = new RetryLink({ delay: delayStub, attempts: { max: 3 } });
-    const linkStub = jest.fn(() => new Observable(o => o.error(standardError)));
+    const linkStub = jest.fn(() => fromError(standardError));
     const link = ApolloLink.from([retry, linkStub]);
     const [{ error }] = await waitFor(execute(link, { query }));
 
@@ -151,7 +157,7 @@ describe('RetryLink', () => {
       delay: { initial: 1 },
       attempts: attemptStub,
     });
-    const linkStub = jest.fn(() => new Observable(o => o.error(standardError)));
+    const linkStub = jest.fn(() => fromError(standardError));
     const link = ApolloLink.from([retry, linkStub]);
     const [{ error }] = await waitFor(execute(link, { query }));
 

--- a/packages/apollo-link-retry/src/delayFunction.ts
+++ b/packages/apollo-link-retry/src/delayFunction.ts
@@ -41,9 +41,11 @@ export interface DelayFunctionOptions {
   jitter?: boolean;
 }
 
-export function buildDelayFunction(
-  { initial = 300, max = Infinity, jitter = true }: DelayFunctionOptions = {},
-): DelayFunction {
+export function buildDelayFunction({
+  initial = 300,
+  max = Infinity,
+  jitter = true,
+}: DelayFunctionOptions = {}): DelayFunction {
   let baseDelay;
   if (jitter) {
     // If we're jittering, baseDelay is half of the maximum delay for that

--- a/packages/apollo-link-retry/src/retryFunction.ts
+++ b/packages/apollo-link-retry/src/retryFunction.ts
@@ -30,9 +30,10 @@ export interface RetryFunctionOptions {
   retryIf?: (error: any, operation: Operation) => boolean;
 }
 
-export function buildRetryFunction(
-  { max = 5, retryIf }: RetryFunctionOptions = {},
-): RetryFunction {
+export function buildRetryFunction({
+  max = 5,
+  retryIf,
+}: RetryFunctionOptions = {}): RetryFunction {
   return function retryFunction(count, operation, error) {
     if (count >= max) return false;
     return retryIf ? retryIf(error, operation) : !!error;

--- a/packages/apollo-link/CHANGELOG.md
+++ b/packages/apollo-link/CHANGELOG.md
@@ -1,33 +1,34 @@
 # Change log
 
 ### vNEXT
+- Add `fromError` Observable helper
 
-# 1.1.0
+### 1.1.0
 - Expose `#execute` on ApolloLink as static
 
-# 1.0.7
+### 1.0.7
 
 - Update to graphql@0.12
 
-# 1.0.6
+### 1.0.6
 - update rollup
 
-# 1.0.5
+### 1.0.5
 - fix bug where context wasn't merged when setting it
 
-# 1.0.4
+### 1.0.4
 - export link util helpers
 
-# 1.0.3
+### 1.0.3
 - removed requiring query on initial execution check
 - moved to move efficent rollup build
 
-# 1.0.1, 1.0.2
+### 1.0.1, 1.0.2
 <!-- never published as latest -->
 - preleases for dev tool integation
 
-# 0.8.0
+### 0.8.0
 - added support for `extensions` on an operation
 
-# 0.7.0
+### 0.7.0
 - new operation API and start of changelog

--- a/packages/apollo-link/src/__tests__/linkUtils.ts
+++ b/packages/apollo-link/src/__tests__/linkUtils.ts
@@ -1,4 +1,9 @@
-import { validateOperation, fromPromise, makePromise } from '../linkUtils';
+import {
+  validateOperation,
+  fromPromise,
+  makePromise,
+  fromError,
+} from '../linkUtils';
 import * as Observable from 'zen-observable';
 
 describe('Link utilities:', () => {
@@ -33,7 +38,7 @@ describe('Link utilities:', () => {
     });
 
     it('return error call as Promise rejection', () => {
-      return makePromise(new Observable(observer => observer.error(error)))
+      return makePromise(fromError(error))
         .then(expect.fail)
         .catch(actualError => expect(error).toEqual(actualError));
     });
@@ -77,6 +82,15 @@ describe('Link utilities:', () => {
 
     it('return Promise rejection as error call', () => {
       const observable = fromPromise(Promise.reject(error));
+      return makePromise(observable)
+        .then(expect.fail)
+        .catch(actualError => expect(error).toEqual(actualError));
+    });
+  });
+  describe('fromError', () => {
+    it('acts as error call', () => {
+      const error = new Error('I always error');
+      const observable = fromError(error);
       return makePromise(observable)
         .then(expect.fail)
         .catch(actualError => expect(error).toEqual(actualError));

--- a/packages/apollo-link/src/index.ts
+++ b/packages/apollo-link/src/index.ts
@@ -1,5 +1,11 @@
 export * from './link';
-export { createOperation, makePromise, toPromise, fromPromise } from './linkUtils';
+export {
+  createOperation,
+  makePromise,
+  toPromise,
+  fromPromise,
+  fromError,
+} from './linkUtils';
 export * from './types';
 
 import * as Observable from 'zen-observable';

--- a/packages/apollo-link/src/linkUtils.ts
+++ b/packages/apollo-link/src/linkUtils.ts
@@ -67,6 +67,12 @@ export function fromPromise<T>(promise: Promise<T>): Observable<T> {
   });
 }
 
+export function fromError<T>(errorValue: any): Observable<T> {
+  return new Observable<T>(observer => {
+    observer.error(errorValue);
+  });
+}
+
 export function transformOperation(operation: GraphQLRequest): GraphQLRequest {
   const transformedOperation: GraphQLRequest = {
     variables: operation.variables || {},


### PR DESCRIPTION
Review commits separately. In addition to explicitly supporting GETs in apollo-link-http, we ban GETs in apollo-link-batch-http, and add an Observable helper `fromError`.

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [ ] Add your name and email to the AUTHORS file (optional)
- [x] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion