### PR TITLE
Tests for dev warnings on undeclared fetch now delete window.fetch

### DIFF
--- a/packages/apollo-link-batch-http/src/batchHttpLink.ts
+++ b/packages/apollo-link-batch-http/src/batchHttpLink.ts
@@ -49,7 +49,7 @@ export class BatchHttpLink extends ApolloLink {
     let {
       uri = '/graphql',
       // use default global fetch is nothing passed in
-      fetch: fetcher = fetch,
+      fetch: fetcher,
       includeExtensions,
       batchInterval,
       batchMax,
@@ -59,6 +59,13 @@ export class BatchHttpLink extends ApolloLink {
 
     // dev warnings to ensure fetch is present
     checkFetcher(fetcher);
+
+    //fetcher is set here rather than the destructuring to ensure fetch is
+    //declared before referencing it. Reference in the destructuring would cause
+    //a ReferenceError
+    if (!fetcher) {
+      fetcher = fetch;
+    }
 
     const linkConfig = {
       http: { includeExtensions },

--- a/packages/apollo-link-http-common/src/__tests__/index.ts
+++ b/packages/apollo-link-http-common/src/__tests__/index.ts
@@ -208,15 +208,23 @@ describe('Common Http functions', () => {
   });
 
   describe('checkFetcher', () => {
+    let oldFetch;
+    beforeEach(() => {
+      oldFetch = window.fetch;
+      delete window.fetch;
+    });
+
+    afterEach(() => {
+      window.fetch = oldFetch;
+    });
+
     it('throws if no fetch is present', () => {
-      if (typeof fetch !== 'undefined') fetch = undefined;
       expect(() => checkFetcher(undefined)).toThrow(
         /fetch is not found globally/,
       );
     });
 
     it('does not throws if no fetch is present but a fetch is passed', () => {
-      if (typeof fetch !== 'undefined') fetch = undefined;
       expect(() => checkFetcher(() => {})).not.toThrow();
     });
   });

--- a/packages/apollo-link-http-common/src/index.ts
+++ b/packages/apollo-link-http-common/src/index.ts
@@ -164,17 +164,15 @@ export const checkFetcher = (fetcher: GlobalFetch['fetch']) => {
   if (!fetcher && typeof fetch === 'undefined') {
     let library: string = 'unfetch';
     if (typeof window === 'undefined') library = 'nodefetch';
-    throw new Error(
-      `fetch is not found globally and no fetcher passed, to fix pass a fetch for
-      your environment like https://www.npmjs.com/package/${library}.
+    throw new Error(`
+fetch is not found globally and no fetcher passed, to fix pass a fetch for
+your environment like https://www.npmjs.com/package/${library}.
 
-      For example:
-      import fetch from '${library}';
-      import { createHttpLink } from 'apollo-link-http';
+For example:
+import fetch from '${library}';
+import { createHttpLink } from 'apollo-link-http';
 
-      const link = createHttpLink({ uri: '/graphql', fetch: fetch });
-      `,
-    );
+const link = createHttpLink({ uri: '/graphql', fetch: fetch });`);
   }
 };
 

--- a/packages/apollo-link-http/src/__tests__/sharedHttpTests.ts
+++ b/packages/apollo-link-http/src/__tests__/sharedHttpTests.ts
@@ -618,8 +618,17 @@ export const sharedHttpTest = (
   });
 
   describe('dev warnings', () => {
-    it('warns if no fetch is present', done => {
-      if (typeof fetch !== 'undefined') fetch = undefined;
+    let oldFetch;
+    beforeEach(() => {
+      oldFetch = window.fetch;
+      delete window.fetch;
+    });
+
+    afterEach(() => {
+      window.fetch = oldFetch;
+    });
+
+    it('warns if fetch is undeclared', done => {
       try {
         const link = createLink({ uri: 'data' });
         done.fail("warning wasn't called");
@@ -630,8 +639,19 @@ export const sharedHttpTest = (
       }
     });
 
-    it('does not warn if no fetch is present but a fetch is passed', () => {
-      if (typeof fetch !== 'undefined') fetch = undefined;
+    it('warns if fetch is undefined', done => {
+      window.fetch = undefined;
+      try {
+        const link = createLink({ uri: 'data' });
+        done.fail("warning wasn't called");
+      } catch (e) {
+        makeCallback(done, () =>
+          expect(e.message).toMatch(/fetch is not found globally/),
+        )();
+      }
+    });
+
+    it('does not warn if fetch is undeclared but a fetch is passed', () => {
       expect(() => {
         const link = createLink({ uri: 'data', fetch: () => {} });
       }).not.toThrow();

--- a/packages/apollo-link-http/src/httpLink.ts
+++ b/packages/apollo-link-http/src/httpLink.ts
@@ -25,13 +25,20 @@ export const createHttpLink = (linkOptions: HttpLink.Options = {}) => {
   let {
     uri = '/graphql',
     // use default global fetch is nothing passed in
-    fetch: fetcher = fetch,
+    fetch: fetcher,
     includeExtensions,
     ...requestOptions
   } = linkOptions;
 
   // dev warnings to ensure fetch is present
   checkFetcher(fetcher);
+
+  //fetcher is set here rather than the destructuring to ensure fetch is
+  //declared before referencing it. Reference in the destructuring would cause
+  //a ReferenceError
+  if (!fetcher) {
+    fetcher = fetch;
+  }
 
   const linkConfig = {
     http: { includeExtensions },


### PR DESCRIPTION
The tests checking for dev warnings for an undeclared fetch now delete fetch from the window as a browser would.

Thank you @glasser for pointing it out!