### PR TITLE
Add missing global Rollup alias for apollo-link-http-common

### DIFF
--- a/packages/apollo-link-http-common/rollup.config.js
+++ b/packages/apollo-link-http-common/rollup.config.js
@@ -1,3 +1,3 @@
 import build from '../../rollup.config';
 
-export default build('utilities');
+export default build('httpCommon');

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,6 +6,7 @@ export const globals = {
   'apollo-link': 'apolloLink.core',
   'apollo-link-batch': 'apolloLink.batch',
   'apollo-utilities': 'apollo.utilities',
+  'apollo-link-http-common': 'apolloLink.utilities',
   'zen-observable-ts': 'apolloLink.zenObservable',
 
   //GraphQL

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ export const globals = {
   'apollo-link': 'apolloLink.core',
   'apollo-link-batch': 'apolloLink.batch',
   'apollo-utilities': 'apollo.utilities',
-  'apollo-link-http-common': 'apolloLink.utilities',
+  'apollo-link-http-common': 'apolloLink.httpCommon',
   'zen-observable-ts': 'apolloLink.zenObservable',
 
   //GraphQL


### PR DESCRIPTION
This fixes #521, making it so that the apollo-link-http bundle resolves
apollo-link-http-common to global.apolloLink.utilities instead of
global.apolloLinkHttpCommon (which does not exist).
