### PR TITLE
hotfix issue where errors fired the next cb even if no data was present

### DIFF
--- a/packages/apollo-link-batch-http/CHANGELOG.md
+++ b/packages/apollo-link-batch-http/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ### vNext
 
+### 1.2.0
+- support passing data and errors back as data to next link
+
 ### 1.1.1
-- udate apollo link with zen-observable-ts [PR#515](https://github.com/apollographql/apollo-link/pull/515)
+- update apollo link with zen-observable-ts [PR#515](https://github.com/apollographql/apollo-link/pull/515)
 
 ### 1.1.0
 - share logic with apollo-link-http through apollo-link-http-core [PR#364](https://github.com/apollographql/apollo-link/pull/364)

--- a/packages/apollo-link-batch-http/src/batchHttpLink.ts
+++ b/packages/apollo-link-batch-http/src/batchHttpLink.ts
@@ -137,6 +137,42 @@ export class BatchHttpLink extends ApolloLink {
           .catch(err => {
             // fetch was cancelled so its already been cleaned up in the unsubscribe
             if (err.name === 'AbortError') return;
+            // if it is a network error, BUT there is graphql result info
+            // fire the next observer before calling error
+            // this gives apollo-client (and react-apollo) the `graphqlErrors` and `networErrors`
+            // to pass to UI
+            // this should only happen if we *also* have data as part of the response key per
+            // the spec
+            if (err.result && err.result.errors && err.result.data) {
+              // if we dont' call next, the UI can only show networkError because AC didn't
+              // get andy graphqlErrors
+              // this is graphql execution result info (i.e errors and possibly data)
+              // this is because there is no formal spec how errors should translate to
+              // http status codes. So an auth error (401) could have both data
+              // from a public field, errors from a private field, and a status of 401
+              // {
+              //  user { // this will have errors
+              //    firstName
+              //  }
+              //  products { // this is public so will have data
+              //    cost
+              //  }
+              // }
+              //
+              // the result of above *could* look like this:
+              // {
+              //   data: { products: [{ cost: "$10" }] },
+              //   errors: [{
+              //      message: 'your session has timed out',
+              //      path: []
+              //   }]
+              // }
+              // status code of above would be a 401
+              // in the UI you want to show data where you can, errors as data where you can
+              // and use correct http status codes
+              observer.next(err.result);
+            }
+
             observer.error(err);
           });
 

--- a/packages/apollo-link-http/CHANGELOG.md
+++ b/packages/apollo-link-http/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ### vNEXT
 
+### 1.5.2
+- fix issue where execution result with only `errors` key fired the `next` event
+
 ### 1.5.1
-- udate apollo link with zen-observable-ts [PR#515](https://github.com/apollographql/apollo-link/pull/515)
+- update apollo link with zen-observable-ts [PR#515](https://github.com/apollographql/apollo-link/pull/515)
 
 ### 1.5.0
 - New useGETForQueries option: if set, uses GET for queries (but not mutations)

--- a/packages/apollo-link-http/src/httpLink.ts
+++ b/packages/apollo-link-http/src/httpLink.ts
@@ -125,7 +125,9 @@ export const createHttpLink = (linkOptions: HttpLink.Options = {}) => {
           // fire the next observer before calling error
           // this gives apollo-client (and react-apollo) the `graphqlErrors` and `networErrors`
           // to pass to UI
-          if (err.result && err.result.errors) {
+          // this should only happen if we *also* have data as part of the response key per
+          // the spec
+          if (err.result && err.result.errors && err.result.data) {
             // if we dont' call next, the UI can only show networkError because AC didn't
             // get andy graphqlErrors
             // this is graphql execution result info (i.e errors and possibly data)


### PR DESCRIPTION
This fixes a bug introduced in #468 where execution results with no `data` field were still treated as errors with data. This didn't match the spec and this PR fixes that problem!