### PR TITLE
Fixed typing of Operation parameters

### DIFF
--- a/packages/apollo-link-batch-http/src/batchHttpLink.ts
+++ b/packages/apollo-link-batch-http/src/batchHttpLink.ts
@@ -36,7 +36,7 @@ export namespace BatchHttpLink {
     /**
      * Sets the key for an Operation, which specifies the batch an operation is included in
      */
-    batchKey?: (Operation) => string;
+    batchKey?: (operation: Operation) => string;
   }
 }
 

--- a/packages/apollo-link-batch/src/batchLink.ts
+++ b/packages/apollo-link-batch/src/batchLink.ts
@@ -33,7 +33,7 @@ export namespace BatchLink {
     /**
      * creates the key for a batch
      */
-    batchKey?: (Operation) => string;
+    batchKey?: (operation: Operation) => string;
   }
 }
 

--- a/packages/apollo-link-batch/src/batching.ts
+++ b/packages/apollo-link-batch/src/batching.ts
@@ -31,7 +31,7 @@ export class OperationBatcher {
 
   //This function is called to the queries in the queue to the server.
   private batchHandler: BatchHandler;
-  private batchKey: (Operation) => string;
+  private batchKey: (operation: Operation) => string;
 
   constructor({
     batchInterval,
@@ -42,7 +42,7 @@ export class OperationBatcher {
     batchInterval: number;
     batchMax?: number;
     batchHandler: BatchHandler;
-    batchKey?: (Operation) => string;
+    batchKey?: (operation: Operation) => string;
   }) {
     this.queuedRequests = new Map();
     this.batchInterval = batchInterval;

--- a/packages/apollo-link-http-common/src/index.ts
+++ b/packages/apollo-link-http-common/src/index.ts
@@ -258,7 +258,7 @@ export const serializeFetchParameter = (p, label) => {
 //selects "/graphql" by default
 export const selectURI = (
   operation,
-  fallbackURI?: string | ((Operation) => string),
+  fallbackURI?: string | ((operation: Operation) => string),
 ) => {
   const context = operation.getContext();
   const contextURI = context.uri;


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
Currently I'm getting an error due to having noImplicitAny turned on. This PR should hopefully fix these. e.g.:

ERROR at node_modules/apollo-link-batch-http/lib/batchHttpLink.d.ts(7,21):
TS7006: Parameter 'Operation' implicitly has an 'any' type.
Version: typescript 2.7.2

Thanks!