### PR TITLE
apollo-link: moved @types/node to dev depenencies in package.json

### DIFF
--- a/packages/apollo-link/CHANGELOG.md
+++ b/packages/apollo-link/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### vNEXT
 - export graphql types and add @types/graphql as a regular dependency [PR#576](https://github.com/apollographql/apollo-link/pull/576)
+- moved @types/node to dev dependencies in package.josn to avoid collisions with other projects. [PR#540](https://github.com/apollographql/apollo-link/pull/540)
 
 ### 1.2.1
 - update apollo link with zen-observable-ts to remove import issues [PR#515](https://github.com/apollographql/apollo-link/pull/515)

--- a/packages/apollo-link/package.json
+++ b/packages/apollo-link/package.json
@@ -42,7 +42,6 @@
   },
   "dependencies": {
     "@types/graphql": "0.12.6",
-    "@types/node": "^9.4.6",
     "apollo-utilities": "^1.0.0",
     "zen-observable-ts": "^0.8.6"
   },
@@ -51,6 +50,7 @@
   },
   "devDependencies": {
     "@types/jest": "21.1.10",
+    "@types/node": "^9.4.6",
     "browserify": "16.1.1",
     "graphql": "0.13.2",
     "graphql-tag": "2.8.0",


### PR DESCRIPTION
Forgive me as this is my first PR ever, so I'm not well versed in this :)

My company is having problems using React Native + TypeScript + Apollo due to apollo-link requiring `@types/node` in dependencies instead of dev dependencies. This is causing an error: 

`node_modules/@types/node/index.d.ts(140,13): error TS2300: Duplicate identifier 'require'.` 

I simply moved it to dev dependencies, ran tests to make sure that nothing broke, and submitted.

Also whatever git hooks that run on commit caused the formatting changes in package.json. I couldn't get around it, so sorry if that makes anybody sad.

<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Make sure all of new logic is covered by tests and passes linting
- [x] Update CHANGELOG.md with your change

**Pull Request Labels**

<!--
While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

<!--
To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->
