### PR TITLE
Add apollo-link-firebase

### DIFF
--- a/docs/source/links/community.md
+++ b/docs/source/links/community.md
@@ -24,3 +24,4 @@ Thank you to our amazing community members who have created custom Apollo Links!
 - [apollo-link-serialize](https://github.com/helfer/apollo-link-serialize) by [@helfer](https://github.com/helfer): Serializes requests by key to ensure execution order
 - [apollo-link-debounce](https://github.com/helfer/apollo-link-debounce) by [@helfer](https://github.com/helfer): Debounce requests made within an interval
 - [apollo-link-defer](https://github.com/leadiq/apollo-link-defer) by [@leadiq](https://github.com/leadiq): Prepare links asynchronously, even after `ApolloClient` construction
+- [apollo-link-firebase](https://github.com/Canner/apollo-link-firebase) by [@canner](https://github.com/Canner): Query Firebase with Apollo


### PR DESCRIPTION
Hey guys!
As a firebase user and apollo graphQL lover, I opensource a new apollo-link project that connects to firebase.
In this project, we support query/mutation/subscription, and even data join.
More details on our document.

TODO:

- [x] Make sure all of new logic is covered by tests and passes linting
- [] Update CHANGELOG.md with your change
