### PR TITLE
Keep JSDoc Comments in TypeScript output!

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["es6", "dom"],
     "module": "es2015",
     "moduleResolution": "node",
-    "removeComments": true,
+    "removeComments": false,
     "sourceMap": true,
     "declaration": true,
     "noImplicitAny": false,


### PR DESCRIPTION
We should keep the JSDoc comments for friendlier Editor integration & easier learning curve.

This follows a similar PR from apollo-client: https://github.com/apollographql/apollo-client/pull/3086

TODO:

- [x] Doesn't change code function (passes tests equally to existing)
- [ ] Update Changelog _should I update the changelog in every single nested package??_

**Pull Request Labels**

<!--
While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [ ] feature
- [ ] blocking
- [x] docs