### PR TITLE
Http: Check for signal on fetch options before adding own abort controller

### DIFF
--- a/packages/apollo-link-batch-http/src/batchHttpLink.ts
+++ b/packages/apollo-link-batch-http/src/batchHttpLink.ts
@@ -121,8 +121,12 @@ export class BatchHttpLink extends ApolloLink {
         return fromError<FetchResult[]>(parseError);
       }
 
-      const { controller, signal } = createSignalIfSupported();
-      if (controller) (options as any).signal = signal;
+      let controller;
+      if (!(options as any).signal) {
+        const { controller: _controller, signal } = createSignalIfSupported();
+        controller = _controller;
+        if (controller) (options as any).signal = signal;
+      }
 
       return new Observable<FetchResult[]>(observer => {
         // the raw response is attached to the context in the BatchingLink

--- a/packages/apollo-link-http/src/httpLink.ts
+++ b/packages/apollo-link-http/src/httpLink.ts
@@ -77,8 +77,12 @@ export const createHttpLink = (linkOptions: HttpLink.Options = {}) => {
       contextConfig,
     );
 
-    const { controller, signal } = createSignalIfSupported();
-    if (controller) (options as any).signal = signal;
+    let controller;
+    if (!(options as any).signal) {
+      const { controller: _controller, signal } = createSignalIfSupported();
+      controller = _controller;
+      if (controller) (options as any).signal = signal;
+    }
 
     // If requested, set method to GET if there are no mutations.
     const definitionIsMutation = (d: DefinitionNode) => {


### PR DESCRIPTION
Currently if the user passes in a signal option, it gets overwritten if a controller is successfully made. This should not be the case as something outside of the http links should be able to abort the fetch request. 

- [x] Make sure all of new logic is covered by tests and passes linting
- [ ] Update CHANGELOG.md with your change

**Pull Request Labels**

/label bug
