### PR TITLE
Hoist Renovate config from nested `package.json` into root `renovate.json`.

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -20,10 +20,5 @@
     "build": "chexo apollo-hexo-config -- generate",
     "clean": "hexo clean",
     "test": "npm run clean; npm run build"
-  },
-  "renovate": {
-    "extends": [
-      "apollo-docs"
-    ]
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,11 @@
   "automerge": "minor",
   "labels": ["tooling", "dependencies"],
   "assignees": ["@jbaxleyiii"],
-  "reviewers": ["@jbaxleyiii"]
+  "reviewers": ["@jbaxleyiii"],
+  "pathRules": [{
+    "paths": ["docs/package.json"],
+    "extends": [
+      "apollo-docs"
+    ]
+  }]
 }


### PR DESCRIPTION
Closes #592.