### PR TITLE
Fix cache.writeData call in apollo-link-state doc

### DIFF
--- a/docs/source/links/state.md
+++ b/docs/source/links/state.md
@@ -136,9 +136,11 @@ This is the same as calling `writeData` yourself with an initial value:
 ```js
 // Same as passing defaults above
 cache.writeData({
-  networkStatus: {
-    __typename: 'NetworkStatus',
-    isConnected: true,
+  data: {
+    networkStatus: {
+      __typename: 'NetworkStatus',
+     isConnected: true,
+    },
   },
 });
 ```


### PR DESCRIPTION
As I understand `cache.writeData`, it expects an object with a `data` property as its first argument. There's a code example in `state.md` that passes in the data object unwrapped, which led me astray.

(I take it this doesn't require a `CHANGELOG` addition anywhere, being a docs change?)

- [ ] feature
- [ ] blocking
- [x] docs
