### PR TITLE
Doc: fix wrong default RetryLink imports

### DIFF
--- a/docs/source/composition.md
+++ b/docs/source/composition.md
@@ -30,10 +30,10 @@ const link = ApolloLink.from([
 
 ```js
 import { ApolloLink } from 'apollo-link';
-import Retry from 'apollo-link-retry';
+import { RetryLink } from 'apollo-link-retry';
 import HttpLink from 'apollo-link-http';
 
-const link = ApolloLink.concat(new Retry(), new HttpLink({ uri: '/graphql' }));
+const link = ApolloLink.concat(new RetryLink(), new HttpLink({ uri: '/graphql' }));
 ```
 
 <h2 id="directional">Directional Composition</h2>
@@ -42,10 +42,10 @@ Given that links are a way of implementing custom control flow for your GraphQL 
 
 ```js
 import { ApolloLink } from 'apollo-link';
-import Retry from 'apollo-link-retry';
+import { RetryLink } from 'apollo-link-retry';
 import HttpLink from 'apollo-link-http';
 
-const link = new Retry().split(
+const link = new RetryLink().split(
   (operation) => operation.getContext().version === 1,
   new HttpLink({ uri: "/v1/graphql" }),
   new HttpLink({ uri: "/v2/graphql" })


### PR DESCRIPTION
As per https://github.com/apollographql/apollo-link/blob/master/packages/apollo-link-retry/src/retryLink.ts#L182

<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Make sure all of new logic is covered by tests and passes linting
- [ ] Update CHANGELOG.md with your change

**Pull Request Labels**

<!--
While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [ ] feature
- [ ] blocking
- [x] docs

<!--
To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->
