### PR TITLE
apollo-link-error: request return type FetchResult, not ExecutionResult

### DIFF
--- a/packages/apollo-link-error/src/index.ts
+++ b/packages/apollo-link-error/src/index.ts
@@ -1,4 +1,10 @@
-import { ApolloLink, Observable, Operation } from 'apollo-link';
+import {
+  ApolloLink,
+  Observable,
+  Operation,
+  NextLink,
+  FetchResult,
+} from 'apollo-link';
 import { GraphQLError, ExecutionResult } from 'graphql';
 
 export interface ErrorResponse {
@@ -66,7 +72,10 @@ export class ErrorLink extends ApolloLink {
     this.link = onError(errorHandler);
   }
 
-  public request(operation, forward): Observable<ExecutionResult> | null {
+  public request(
+    operation: Operation,
+    forward: NextLink,
+  ): Observable<FetchResult> | null {
     return this.link.request(operation, forward);
   }
 }


### PR DESCRIPTION
- [ ] Make sure all of new logic is covered by tests and passes linting
- [ ] Update CHANGELOG.md with your change

**Pull Request Labels**

<!--
While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [ ] feature
- [x] blocking
- [ ] docs

<!--
To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

 fixes #599