### PR TITLE
Updates section on Additive Composition

### DIFF
--- a/docs/source/composition.md
+++ b/docs/source/composition.md
@@ -25,15 +25,25 @@ const link = ApolloLink.from([
 ]);
 ```
 
-`from` is typically used when you have many links to join together all at once. The alternative way to join links is the `concat` method which joins two links together into one.
+`from` is typically used when you have many links to join together all at once. The alternative way to join links is the `concat` method, that can be found on any instance of `ApolloLink` or imported as a standalone function, which joins two links together into one.
 
 
 ```js
-import { ApolloLink } from 'apollo-link';
 import { RetryLink } from 'apollo-link-retry';
 import HttpLink from 'apollo-link-http';
 
-const link = ApolloLink.concat(new RetryLink(), new HttpLink({ uri: '/graphql' }));
+const retryLink = new RetryLink();
+const httpLink = new HttpLink({ uri: '/graphql' });
+
+const link = retryLink.concat(httpLink);
+```
+or
+```js
+import { concat } from 'apollo-link';
+import { RetryLink } from 'apollo-link-retry';
+import HttpLink from 'apollo-link-http';
+
+const link = concat(new RetryLink(), new HttpLink({ uri: '/graphql' }));
 ```
 
 <h2 id="directional">Directional Composition</h2>


### PR DESCRIPTION
`ApolloLink` does not have a static `concat()` method. It's and instance method. Or available as a standalone package function.

<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Make sure all of new logic is covered by tests and passes linting
- [ ] Update CHANGELOG.md with your change

**Pull Request Labels**

<!--
While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [ ] feature
- [ ] blocking
- [x] docs

<!--
To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->
