### PR TITLE
Fix double error thrown if http_status > 300 && result has data

### DIFF
--- a/packages/apollo-link-http/src/httpLink.ts
+++ b/packages/apollo-link-http/src/httpLink.ts
@@ -159,6 +159,7 @@ export const createHttpLink = (linkOptions: HttpLink.Options = {}) => {
             // in the UI you want to show data where you can, errors as data where you can
             // and use correct http status codes
             observer.next(err.result);
+            return;
           }
           observer.error(err);
         });


### PR DESCRIPTION
Issue is described in detail in [#542](https://github.com/apollographql/apollo-link/issues/542).

In summary:
If `apollo-link-http` receives an error but the response has data to be presented, it will call `.next(err.result);` in the request observable and then call `.error()` in the same observable.
Since the 1st call (`.next(...)`) ends up closing the observable/stream, the 2nd call (`.error()`) will throw an error which is pretty much uncatchable. This is exceptionally bad when using Apollo in ReactNative since this exception crashes the application.

The solution simply `return` after the call to `.next(...)` to avoid the late call to `.error()`.

<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Make sure all of new logic is covered by tests and passes linting
- [ ] Update CHANGELOG.md with your change

**Pull Request Labels**

<!--
While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [ ] feature
- [x] blocking
- [ ] docs

<!--
To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->
