### PR TITLE
Fix zen-observable typescript import

### DIFF
--- a/packages/apollo-link/src/index.ts
+++ b/packages/apollo-link/src/index.ts
@@ -8,5 +8,5 @@ export {
 } from './linkUtils';
 export * from './types';
 
-import Observable from 'zen-observable-ts';
+import Observable = require('zen-observable');
 export { Observable };


### PR DESCRIPTION
Because zen observable uses the `export = Observable`, it should be imported using the form  `import Observable = require('zen-observable');`.

See https://www.typescriptlang.org/docs/handbook/modules.html under the heading "export = and import = require()":

> When exporting a module using `export =`, TypeScript-specific `import module = require("module")` must be used to import the module.

This error occurs if your tsconfig has 

```
    "esModuleInterop": true,
```

Setting that option to false prevents the error.
