### PR TITLE
Add apollo-link-intercept

### DIFF
--- a/packages/apollo-link-intercept/README.md
+++ b/packages/apollo-link-intercept/README.md
@@ -1,0 +1,47 @@
+---
+title: apollo-link-intercept
+description: Intercept data and errors from links further in the chain
+---
+
+Use this link to respond to results and/or errors from a link further in the chain. Use cases include:
+
+- logging or recording metrics on successful and failed GraphQL operations
+- treating certain results as errors, or errors as successful results
+- retrying failed operations (see [apollo-link-retry](../apollo-link-retry))
+
+<h2 id="example">Example</h2>
+
+Here’s an example of using `apollo-link-intercept` and [`hot-shots`](https://www.npmjs.com/package/hot-shots) to record statistics on GraphQL operations:
+
+```js
+import { ApolloLink } from "apollo-link";
+import { interceptLink } from "apollo-link-intercept";
+import StatsD from "hot-shots";
+
+const statsd = new StatsD();
+
+const intercept = interceptLink(operation => {
+  const startTime = Date.now()
+  const tags = [`operation:${operation.operationName}`]
+
+  return {
+    next(result, { next }) {
+      let duration = Date.now() - startTime
+      let hasError = result.errors && result.errors.length > 0
+      statsd.timing('graphql.response.time', duration, tags.concat([`error:${error}`]))
+      next(result)
+    },
+
+    error(err, { error }) {
+      let duration = Date.now() - startTime
+      statsd.timing('graphql.response.time', duration, tags.concat(['error:yes']))
+      error(err)
+    },
+  }
+})
+
+export default ApolloLink.of([
+  intercept,
+  http, // a link you set up that actually talks to your GraphQL server
+])
+```

--- a/packages/apollo-link-intercept/package.json
+++ b/packages/apollo-link-intercept/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "apollo-link-intercept",
+  "version": "2.0.0",
+  "description": "Helper for building an Apollo Link that intercepts upstream events",
+  "author": "Lyra Naeseth <lyra@medium.com>",
+  "license": "MIT",
+  "main": "./lib/bundle.umd.js",
+  "module": "./lib/index.js",
+  "jsnext:main": "./lib/index.js",
+  "typings": "./lib/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/apollographql/apollo-link.git"
+  },
+  "bugs": {
+    "url": "https://github.com/apollographql/apollo-link/issues"
+  },
+  "homepage": "https://github.com/apollographql/apollo-link/tree/master/packages/apollo-link-intercept#readme",
+  "scripts": {
+    "build:browser": "browserify ./lib/bundle.umd.js -o=./lib/bundle.js --i apollo-link && npm run minify:browser",
+    "build": "tsc -p .",
+    "bundle": "rollup -c",
+    "clean": "rimraf lib/* && rimraf coverage/*",
+    "coverage": "jest --coverage",
+    "filesize": "npm run build && npm run build:browser",
+    "lint": "tslint --type-check -p tsconfig.json -c ../../tslint.json src/*.ts",
+    "minify:browser": "uglifyjs -c -m -o ./lib/bundle.min.js -- ./lib/bundle.js",
+    "postbuild": "npm run bundle",
+    "prebuild": "npm run clean",
+    "prepublishOnly": "npm run clean && npm run build",
+    "test": "jest",
+    "watch": "tsc -w -p . & rollup -c -w"
+  },
+  "dependencies": {
+    "@types/zen-observable": "0.5.3",
+    "apollo-link": "^1.2.2"
+  },
+  "devDependencies": {
+    "@types/graphql": "0.12.6",
+    "@types/jest": "22.2.2",
+    "browserify": "16.1.1",
+    "graphql": "0.13.2",
+    "graphql-tag": "2.8.0",
+    "jest": "22.4.3",
+    "rimraf": "2.6.1",
+    "rollup": "0.57.1",
+    "ts-jest": "21.2.4",
+    "tslint": "5.9.1",
+    "typescript": "2.7.2",
+    "uglify-js": "3.3.16",
+    "wait-for-observables": "1.0.3"
+  },
+  "jest": {
+    "transform": {
+      ".(ts|tsx)": "ts-jest"
+    },
+    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "json"
+    ],
+    "mapCoverage": true
+  }
+}

--- a/packages/apollo-link-intercept/rollup.config.js
+++ b/packages/apollo-link-intercept/rollup.config.js
@@ -1,0 +1,3 @@
+import build from '../../rollup.config';
+
+export default build('retry');

--- a/packages/apollo-link-intercept/rollup.config.js
+++ b/packages/apollo-link-intercept/rollup.config.js
@@ -1,3 +1,3 @@
 import build from '../../rollup.config';
 
-export default build('retry');
+export default build('intercept');

--- a/packages/apollo-link-intercept/src/__tests__/index.ts
+++ b/packages/apollo-link-intercept/src/__tests__/index.ts
@@ -1,0 +1,128 @@
+import gql from 'graphql-tag';
+import {
+  execute,
+  ApolloLink,
+  Observable,
+  FetchResult,
+  fromError,
+} from 'apollo-link';
+import waitFor from 'wait-for-observables';
+
+import { interceptLink } from '../';
+
+const query = gql`
+  query Sample {
+    sample {
+      id
+    }
+  }
+`;
+
+const standardError = new Error('I never work');
+
+describe('interceptLink', () => {
+  it('passes through results by default', async () => {
+    const intercept = interceptLink(() => ({}));
+    const data = { data: { hello: 'world' } };
+    const stub = jest.fn(() => Observable.of(data));
+    const link = ApolloLink.from([intercept, stub]);
+
+    const [{ values }] = await waitFor(execute(link, { query }));
+    expect(values).toEqual([data]);
+    expect(stub).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes through errors by default', async () => {
+    const intercept = interceptLink(() => ({}));
+    const stub = jest.fn(() => fromError(standardError));
+    const link = ApolloLink.from([intercept, stub]);
+
+    const [{ error }] = await waitFor(execute(link, { query }));
+    expect(error).toEqual(standardError);
+    expect(stub).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the GraphQL operation to the factory function', async () => {
+    let operation;
+    const intercept = interceptLink(op => {
+      operation = op;
+      return {};
+    });
+
+    const data = { data: { hello: 'world' } };
+    const stub = jest.fn(() => Observable.of(data));
+    const link = ApolloLink.from([intercept, stub]);
+
+    await waitFor(execute(link, { query }));
+    expect(operation).not.toBeNull();
+    expect(operation.operationName).toEqual('Sample');
+  });
+
+  it('delivers different data from the interceptor', async () => {
+    const data = { data: { hello: 'world' } };
+    const replacedData = { data: { goodnight: 'moon' } };
+    const intercept = interceptLink(() => ({
+      next: (value, { next }) => next(replacedData),
+    }));
+    const stub = jest.fn(() => Observable.of(data));
+    const link = ApolloLink.from([intercept, stub]);
+
+    const [{ values }] = await waitFor(execute(link, { query }));
+    expect(values).toEqual([replacedData]);
+    expect(stub).toHaveBeenCalledTimes(1);
+  });
+
+  it('delivers a different error from the interceptor', async () => {
+    const replacedError = new Error('I also never work');
+    const intercept = interceptLink(() => ({
+      error: (err, { error }) => error(replacedError),
+    }));
+    const data = { data: { hello: 'world' } };
+    const stub = jest.fn(() => fromError(standardError));
+    const link = ApolloLink.from([intercept, stub]);
+
+    const [{ error }] = await waitFor(execute(link, { query }));
+    expect(error).toEqual(replacedError);
+    expect(stub).toHaveBeenCalledTimes(1);
+  });
+
+  it('can deliver an error from the next handler', async () => {
+    const data = { data: { hello: 'world' } };
+    const intercept = interceptLink(() => ({
+      next: (value, { error }) => error(standardError),
+    }));
+    const stub = jest.fn(() => Observable.of(data));
+    const link = ApolloLink.from([intercept, stub]);
+
+    const [{ error }] = await waitFor(execute(link, { query }));
+    expect(error).toEqual(standardError);
+    expect(stub).toHaveBeenCalledTimes(1);
+  });
+
+  it('can deliver data from the error handler', async () => {
+    const data = { data: { hello: 'world' } };
+    const intercept = interceptLink(() => ({
+      error: (err, { complete, next }) => {
+        next(data);
+        complete(); // XXX: this is necessary for tests, but will it be for Apollo Client?
+      },
+    }));
+    const stub = jest.fn(() => fromError(standardError));
+    const link = ApolloLink.from([intercept, stub]);
+
+    const [{ values }] = await waitFor(execute(link, { query }));
+    expect(values).toEqual([data]);
+    expect(stub).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls the canceled interceptor method', async () => {
+    const canceled = jest.fn(() => {});
+    const intercept = interceptLink(() => ({ canceled }));
+    const data = { data: { hello: 'world' } };
+    const stub = jest.fn(() => fromError(standardError));
+    const link = ApolloLink.from([intercept, stub]);
+
+    await waitFor(execute(link, { query }));
+    expect(canceled).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/apollo-link-intercept/src/index.ts
+++ b/packages/apollo-link-intercept/src/index.ts
@@ -1,0 +1,198 @@
+import { ApolloLink, Observable, Operation, NextLink } from 'apollo-link';
+
+export interface Actions<TValue = any> {
+  next(value: TValue): void;
+  error(errorValue: any): void;
+  retry(): void;
+  complete(): void;
+  cancel(): void;
+}
+
+export interface Interceptor<TValue> {
+  next(value: TValue, actions: Actions<TValue>): void | Promise<void>;
+  error(errorValue: any, actions: Actions<TValue>): void | Promise<void>;
+  complete(actions: Actions<TValue>): void | Promise<void>;
+  canceled(): void;
+}
+
+export type InterceptorFactory<TValue> = (
+  operation: Operation,
+) => Partial<Interceptor<TValue>>;
+
+export const interceptLink = <T>(
+  interceptorFactory: InterceptorFactory<T>,
+): ApolloLink => {
+  return new ApolloLink((operation, forward) => {
+    const interceptedOperation = new InterceptableOperation(
+      operation,
+      forward,
+      interceptorFactory,
+    );
+    interceptedOperation.start();
+    return interceptedOperation.observe();
+  });
+};
+
+class InterceptableOperation<TValue = any> {
+  private actions: Actions<TValue>;
+  private interceptor: Interceptor<TValue>;
+
+  private values: TValue[] = [];
+  private error: any;
+  private complete = false;
+  private canceled = false;
+  private observers: ZenObservable.Observer<TValue>[] = [];
+  private currentSubscription: ZenObservable.Subscription = null;
+
+  constructor(
+    private operation: Operation,
+    private forward: NextLink,
+    interceptorFactory: InterceptorFactory<TValue>,
+  ) {
+    this.actions = {
+      next: this.deliverNext,
+      error: this.deliverError,
+      complete: this.deliverComplete,
+      retry: this.try,
+      cancel: this.cancel,
+    };
+
+    const interceptor = interceptorFactory(operation);
+
+    this.interceptor = {
+      next:
+        interceptor.next ||
+        ((value: TValue, { next }: Actions<TValue>) => next(value)),
+      error:
+        interceptor.error ||
+        ((err: TValue, { error }: Actions<TValue>) => error(err)),
+      complete:
+        interceptor.complete || (({ complete }: Actions<TValue>) => complete()),
+      canceled: interceptor.canceled || (() => undefined),
+    };
+  }
+
+  public observe(): Observable<TValue> {
+    return new Observable(observer => {
+      this.subscribe(observer);
+      return () => {
+        this.unsubscribe(observer);
+      };
+    });
+  }
+
+  /**
+   * Register a new observer for this operation.
+   *
+   * If the operation has previously emitted other events, they will be
+   * immediately triggered for the observer.
+   */
+  public subscribe(observer: ZenObservable.Observer<TValue>) {
+    if (this.canceled) {
+      throw new Error(
+        `Subscribing to an interceptor link that was canceled is not supported`,
+      );
+    }
+    this.observers.push(observer);
+
+    // If we've already begun, catch this observer up.
+    for (const value of this.values) {
+      observer.next(value);
+    }
+
+    if (this.complete) {
+      observer.complete();
+    } else if (this.error) {
+      observer.error(this.error);
+    }
+  }
+
+  /**
+   * Remove a previously registered observer from this operation.
+   *
+   * If no observers remain, the operation will stop retrying, and unsubscribe
+   * from its downstream link.
+   */
+  public unsubscribe(observer: ZenObservable.Observer<TValue>) {
+    const index = this.observers.indexOf(observer);
+    if (index < 0) {
+      throw new Error(
+        `Attempting to unsubscribe unknown observer from an interceptor link.`,
+      );
+    }
+    // Note that we are careful not to change the order of length of the array,
+    // as we are often mid-iteration when calling this method.
+    this.observers[index] = null;
+
+    // If this is the last observer, we're done.
+    if (this.observers.every(o => o === null)) {
+      this.cancel();
+    }
+  }
+
+  /**
+   * Start the initial request.
+   */
+  public start() {
+    if (this.currentSubscription) return; // Already started.
+
+    this.try();
+  }
+
+  /**
+   * Stop retrying for the operation, and cancel any in-progress requests.
+   */
+  private cancel = () => {
+    if (this.currentSubscription) {
+      this.currentSubscription.unsubscribe();
+    }
+    this.currentSubscription = null;
+    this.canceled = true;
+
+    this.interceptor.canceled();
+  };
+
+  private try = () => {
+    this.currentSubscription = this.forward(this.operation).subscribe({
+      next: this.onNext,
+      error: this.onError,
+      complete: this.onComplete,
+    });
+  };
+
+  private onNext = async (value: TValue) => {
+    await this.interceptor.next(value, this.actions);
+  };
+
+  private deliverNext = (value: TValue) => {
+    this.values.push(value);
+    for (const observer of this.observers) {
+      if (!observer) continue;
+      observer.next(value);
+    }
+  };
+
+  private onError = async error => {
+    await this.interceptor.error(error, this.actions);
+  };
+
+  private deliverError = error => {
+    this.error = error;
+    for (const observer of this.observers) {
+      if (!observer) continue;
+      observer.error(error);
+    }
+  };
+
+  private onComplete = () => {
+    this.interceptor.complete(this.actions);
+  };
+
+  private deliverComplete = () => {
+    this.complete = true;
+    for (const observer of this.observers) {
+      if (!observer) continue;
+      observer.complete();
+    }
+  };
+}

--- a/packages/apollo-link-intercept/tsconfig.json
+++ b/packages/apollo-link-intercept/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "lib"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/__tests__/*.ts"]
+}


### PR DESCRIPTION
The new intercept link is a helper for creating other links that monitor or alter the results from an upstream link.

I don't consider it done – the [readme](https://github.com/silverlyra/apollo-link/tree/intercept/packages/apollo-link-intercept#readme) needs fleshing out, at the very least – but I wanted to stop here to get your thoughts / see if you would even want this in the main apollo-link repo.

At work this week, I wanted to set up a passthrough link like the one given as an example in the readme: being notified both of successful results (even if they only contain errors) as well as network errors, and recording metrics in Datadog.

To accomplish that, I basically ended up reimplementing `RetryableOperation` from apollo-link-retry, which consists mostly of `Observable` management boilerplate and very little retry logic. Not ideal: I implemented a 150-line class just so I could listen to both `next` values and `error`s in one place.

This PR separates out `RetryableOperation` into a new package that offers hooks to implement monitoring, retrying, etc. If merged, in a future PR I'd update apollo-link-retry to use this new package.

TODO:

- [x] Make sure all of new logic is covered by tests and passes linting
- [ ] Update CHANGELOG.md with your change

**Pull Request Labels**

<!--
While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [x] feature
- [ ] blocking
- [ ] docs

<!--
To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->
