### PR TITLE
Update renovate.json to only pin `devDependencies`.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "pinVersions": true,
+  "extends": [":pinOnlyDevDependencies"],
   "semanticCommits": true,
   "depTypes": [{ "depType": "dependencies", "pinVersions": false }],
   "timezone": "America/Los_Angeles",


### PR DESCRIPTION
I'm raising this PR after noticing #583 and https://github.com/apollographql/react-apollo/pull/1921, which exhibited confusing pinning similar to that which I originally discovered in (`apollo-server`'s) https://github.com/apollographql/apollo-server/pull/954.

Specifically, this pinning suggestion (Which will disappear from #583 once this PR lands and Renovate re-bases that PR):

-   [graphql](https://github.com/graphql/graphql-js) (`peerDependencies`): from `^0.11.3 || ^0.12.3 || ^0.13.0` to `0.13.2`
-   [subscriptions-transport-ws](https://github.com/apollostack/subscriptions-transport-ws) (`peerDependencies`): from `^0.9.0` to `0.9.9`

This changes Renovate to only pin the `devDependencies` in a `package.json` rather than all dependencies.

This is in the same spirit as the net result of (apollographql/apollo-server@441cd9b + apollographql/apollo-server@db174a9) which were merged into `apollo-server`, as discussed in apollographql/apollo-server#955 (comment).

(Also same-same as https://github.com/apollographql/react-apollo/pull/1996).