### PR TITLE
Fix batch fetch result on error

### DIFF
--- a/packages/apollo-link-batch-http/CHANGELOG.md
+++ b/packages/apollo-link-batch-http/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNext
+- Fix batch link result on error
 
 ### 1.2.2
 - Update apollo-link [#559](https://github.com/apollographql/apollo-link/pull/559)

--- a/packages/apollo-link-batch-http/src/batchHttpLink.ts
+++ b/packages/apollo-link-batch-http/src/batchHttpLink.ts
@@ -147,7 +147,11 @@ export class BatchHttpLink extends ApolloLink {
             // to pass to UI
             // this should only happen if we *also* have data as part of the response key per
             // the spec
-            if (err.result && err.result.some(i => i.data && i.errors)) {
+            if (
+              err.result &&
+              Array.isArray(err.result) &&
+              err.result.some(i => i.data && i.errors)
+            ) {
               // if we dont' call next, the UI can only show networkError because AC didn't
               // get andy graphqlErrors
               // this is graphql execution result info (i.e errors and possibly data)

--- a/packages/apollo-link-batch-http/src/batchHttpLink.ts
+++ b/packages/apollo-link-batch-http/src/batchHttpLink.ts
@@ -147,7 +147,7 @@ export class BatchHttpLink extends ApolloLink {
             // to pass to UI
             // this should only happen if we *also* have data as part of the response key per
             // the spec
-            if (err.result && err.result.errors && err.result.data) {
+            if (err.result && err.result.some(i => i.data && i.errors)) {
               // if we dont' call next, the UI can only show networkError because AC didn't
               // get andy graphqlErrors
               // this is graphql execution result info (i.e errors and possibly data)


### PR DESCRIPTION
Maybe fix some issues for who uses "apollo-link-batch-http" 

- https://github.com/apollographql/apollo-client/issues/3034
- https://github.com/apollographql/react-apollo/issues/1318
- https://github.com/apollographql/react-apollo/issues/1389

### Problem:
Apollo client does not returns "data" values when has error on fetch. Even if I set errorPolicy 'all' or 'ignore'.

### Cause:
"apollo-link-batch-http" returns Array result on fetch and not a Object.

### Solution:
Fix condition to returns data on fetch error. 

