### PR TITLE
Small typo fix for RetryLink example

### DIFF
--- a/packages/apollo-link-retry/README.md
+++ b/packages/apollo-link-retry/README.md
@@ -66,7 +66,7 @@ The `attempts` function should return a boolean indicating whether the response 
 ```js
 import { RetryLink } from "apollo-link-retry";
 
-const link = new RetryLink(
+const link = new RetryLink({
   attempts: (count, operation, error) => {
     return !!error && operation.operationName != 'specialCase';
   },


### PR DESCRIPTION
Small typo fix.

**Pull Request Labels**
- [x] docs

