### PR TITLE
Bump @types/graphql dependency to 0.13.1

### DIFF
--- a/packages/apollo-link/package.json
+++ b/packages/apollo-link/package.json
@@ -38,7 +38,7 @@
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
-    "@types/graphql": "0.12.6",
+    "@types/graphql": "0.13.1",
     "apollo-utilities": "^1.0.0",
     "zen-observable-ts": "^0.8.9"
   },


### PR DESCRIPTION
- [x] Make sure all of new logic is covered by tests and passes linting
- [x] Update CHANGELOG.md with your change

I'm seeing an issue with my build where it cannot pull down `@types/graphql@0.12.6`, and I think that is due to an upstream NPM issue. But it _can_ pull down `@types/graphql@0.13.1`. But because I use apollo-link, it is "locked" to using 0.12.6.

Bumping this version doesn't do any harm _and_ would fix my build issue.