### PR TITLE
Support retrying failed request in error handler

### DIFF
--- a/packages/apollo-link-error/CHANGELOG.md
+++ b/packages/apollo-link-error/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Change log
 
 ### vNEXT
-
-### 1.0.10
 - Pass `forward` into error handler for ErrorLink to support retrying a failed request 
 
 ### 1.0.9

--- a/packages/apollo-link-error/CHANGELOG.md
+++ b/packages/apollo-link-error/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### vNEXT
 
+### 1.0.10
+- Pass `forward` into error handler for ErrorLink to support retrying a failed request 
+
 ### 1.0.9
 - Correct return type to FetchResult [#600](https://github.com/apollographql/apollo-link/pull/600)
 

--- a/packages/apollo-link-error/README.md
+++ b/packages/apollo-link-error/README.md
@@ -74,6 +74,11 @@ onError(({ graphQLErrors, networkError, operation, forward }) => {
 );
 ```
 
+Here is a diagram of how the request flow looks like now: 
+![Diagram of request flow after retrying in error links](https://imgur.com/a/pWy8G4k)
+
+One caveat is that the errors from the new response from retrying the request does not get passed into the error handler again. This helps to avoid being trapped in an endless request loop when you call forward() in your error handler.
+
 
 <h2 id="ignoring-errors">Ignoring errors</h2>
 

--- a/packages/apollo-link-error/README.md
+++ b/packages/apollo-link-error/README.md
@@ -66,7 +66,9 @@ onError(({ graphQLErrors, networkError, operation, forward }) => {
     }
     if (networkError) {
       console.log(`[Network error]: ${networkError}`);
-      // no need to retry if there was a network error
+      // if you would also like to retry automatically on 
+      // network errors, we recommend that you use 
+      // apollo-link-retry
     }
   }
 );

--- a/packages/apollo-link-error/README.md
+++ b/packages/apollo-link-error/README.md
@@ -29,12 +29,49 @@ Error Link takes a function that is called in the event of an error. This functi
 * `response`: The result returned from lower down in the link chain
 * `graphQLErrors`: An array of errors from the GraphQL endpoint
 * `networkError`: Any error during the link execution or server response, that wasn't delivered as part of the `errors` field in the GraphQL result
+* `forward`: A reference to the next link in the chain. Calling `return forward(operation)` in the callback will retry the request, returning a new observable for the upstream link to subscribe to. 
+
+Returns: `Observable<FetchResult> | void` The error callback can optionally return an observable from calling `forward(operation)` if it wants to retry the request. It should not return anything else. 
 
 <h2 id="error-categories">Error categorization</h2>
 
 An error is passed as a `networkError` if a link further down the chain called the `error` callback on the observable. In most cases, `graphQLErrors` is the `errors` field of the result from the last `next` call.
 
 A `networkError` can contain additional fields, such as a GraphQL object in the case of a [failing HTTP status code](http.html#Errors) from [`apollo-link-http`](http.html). In this situation, `graphQLErrors` is an alias for `networkError.result.errors` if the property exists.
+
+<h2 id="error-categories">Retrying failed requests</h2>
+
+An error handler might want to do more than just logging errors. You can check for a certain failure condition or error code, and retry the request if rectifying the error is possible. For example, when using some form of token based authentication, there is a need to handle re-authentication when the token expires. Here is an example of how to do this using `foward()`.
+```js
+onError(({ graphQLErrors, networkError, operation, forward }) => {
+    if (graphQLErrors) {
+      for (let err of graphQLErrors) {
+        switch (err.extensions.code) {
+          case 'UNAUTHENTICATED': 
+            // error code is set to UNAUTHENTICATED 
+            // when AuthenticationError thrown in resolver
+            
+            // modify the operation context with a new token
+            const oldHeaders = operation.getContext().headers;
+            operation.setContext({
+              headers: {
+                ...oldHeaders,
+                authorization: getNewToken(),
+              },
+            });
+            // retry the request, returning the new observable
+            return forward(operation);
+        }
+      }
+    }
+    if (networkError) {
+      console.log(`[Network error]: ${networkError}`);
+      // no need to retry if there was a network error
+    }
+  }
+);
+```
+
 
 <h2 id="ignoring-errors">Ignoring errors</h2>
 

--- a/packages/apollo-link-error/package.json
+++ b/packages/apollo-link-error/package.json
@@ -58,7 +58,6 @@
       "tsx",
       "js",
       "json"
-    ],
-    "mapCoverage": true
+    ]
   }
 }

--- a/packages/apollo-link-error/src/__tests__/index.ts
+++ b/packages/apollo-link-error/src/__tests__/index.ts
@@ -518,8 +518,7 @@ describe('support for request retrying', () => {
         done();
       },
     });
-  })
-
+  });
 
   it('returns errors from retried requests', done => {
     let errorHandlerCalled = false;

--- a/packages/apollo-link-error/src/__tests__/index.ts
+++ b/packages/apollo-link-error/src/__tests__/index.ts
@@ -1,7 +1,6 @@
 import gql from 'graphql-tag';
 import { ApolloLink, execute, Observable } from 'apollo-link';
 import { onError, ErrorLink } from '../';
-import {} from 'jest';
 
 describe('error handling', () => {
   it('has an easy way to handle GraphQL errors', done => {

--- a/packages/apollo-link-error/src/index.ts
+++ b/packages/apollo-link-error/src/index.ts
@@ -12,6 +12,7 @@ export interface ErrorResponse {
   networkError?: Error;
   response?: ExecutionResult;
   operation: Operation;
+  forward: NextLink;
 }
 
 export namespace ErrorLink {
@@ -19,7 +20,7 @@ export namespace ErrorLink {
    * Callback to be triggered when an error occurs within the link stack.
    */
   export interface ErrorHandler {
-    (error: ErrorResponse): void;
+    (error: ErrorResponse): Observable<FetchResult> | void;
   }
 }
 
@@ -30,36 +31,67 @@ export const onError = (errorHandler: ErrorHandler): ApolloLink => {
   return new ApolloLink((operation, forward) => {
     return new Observable(observer => {
       let sub;
+      let retrySub;
+      let retrying = false;
+
       try {
         sub = forward(operation).subscribe({
           next: result => {
             if (result.errors) {
-              errorHandler({
+              const retryForward = errorHandler({
                 graphQLErrors: result.errors,
                 response: result,
                 operation,
+                forward,
               });
+
+              if (retryForward) {
+                retrying = true;
+                retrySub = retryForward.subscribe({
+                  next: result => observer.next(result),
+                  error: networkError => observer.error(networkError),
+                  complete: observer.complete.bind(observer),
+                });
+                return;
+              }
             }
             observer.next(result);
           },
           error: networkError => {
-            errorHandler({
+            const retryForward = errorHandler({
               operation,
               networkError,
               //Network errors can return GraphQL errors on for example a 403
               graphQLErrors: networkError.result && networkError.result.errors,
+              forward,
             });
+            if (retryForward) {
+              retrying = true;
+              retrySub = retryForward.subscribe({
+                next: result => observer.next(result),
+                error: networkError => observer.error(networkError),
+                complete: observer.complete.bind(observer),
+              });
+              return;
+            }
             observer.error(networkError);
           },
-          complete: observer.complete.bind(observer),
+          complete: () => {
+            // disable the previous sub from calling complete on observable
+            // if retry is in flight.
+            if (!retrying) {
+              observer.complete.bind(observer)();
+            }
+          },
         });
       } catch (e) {
-        errorHandler({ networkError: e, operation });
+        errorHandler({ networkError: e, operation, forward });
         observer.error(e);
       }
 
       return () => {
         if (sub) sub.unsubscribe();
+        if (retrySub) sub.unsubscribe();
       };
     });
   });


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

This PR adds support for retrying failed requests from within ErrorLink's error handler. One use case that this could support is re-authenticating expired tokens on authentication failure, and retrying the request with new tokens. 

TODO:

- [x] Make sure all of new logic is covered by tests and passes linting
- [x] Update CHANGELOG.md with your change

**Pull Request Labels**

<!--
While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [x] feature
- [ ] blocking
- [ ] docs

<!--
To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->
