### PR TITLE
Remove params directive option from docs

### DIFF
--- a/docs/source/links/rest.md
+++ b/docs/source/links/rest.md
@@ -347,11 +347,11 @@ An example use-case would be getting a list of users, and hitting a different en
 ```graphql
 const QUERY = gql`
   query RestData($email: String!) {
-    users @rest(path: '/users/email/:email', params: { email: $email }, method: 'GET', type: 'User') {
+    users @rest(path: '/users/email/:email', method: 'GET', type: 'User') {
       id @export(as: "id")
       firstName
       lastName
-      friends @rest(path: '/friends/:id', params: { id: $id }, type: '[User]') {
+      friends @rest(path: '/friends/:id', type: '[User]') {
         firstName
         lastName
       }


### PR DESCRIPTION
- [x] docs

I don't think the `params` option has ever existed outside of the [initial spec](https://github.com/apollographql/apollo-link-rest/blob/5d94527102bbd6886ba46dbff422f816f0f66aed/designs/initial.md), instead the params are automatically mapped from the docs.