### PR TITLE
Fix typo on overview page

### DIFF
--- a/docs/source/overview.md
+++ b/docs/source/overview.md
@@ -37,7 +37,7 @@ A link's `request` method is called every time `execute` is run on that link cha
 
 The full description of a link's request looks like this:
 - `NextLink`: A function that takes an `Operation` and returns an Observable of an `ExecutionResult`
-- `RequestHandler`: A function which receives an `Operation` and a `NextLink` and returns and Observable of an `ExecutionResult`
+- `RequestHandler`: A function which receives an `Operation` and a `NextLink` and returns an Observable of an `ExecutionResult`
 
 As you can see from these types, the next link is a way to continue the chain of events until data is fetched from some data source (typically a server).
 


### PR DESCRIPTION
”_and_ Observable” should be ”_an_ Observable”.

**Pull Request Labels**

<!--
While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [ ] feature
- [ ] blocking
- [x] docs

<!--
To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->