### PR TITLE
Remove broken link checker from this repository.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
           key: dependency-cache-{{ checksum "./docs/package.json" }}
           paths:
             - ./docs/node_modules
-      - run: cd docs && npm run ci
+      - run: cd docs && npm run build
 
   Filesize:
     docker: [ { image: 'circleci/node:8' } ]

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,15 +14,12 @@
     "hexo-renderer-less": "0.2.0",
     "hexo-renderer-marked": "0.3.2",
     "hexo-server": "0.3.1",
-    "meteor-theme-hexo": "1.0.13",
-    "poke-site": "^1.2.0",
-    "start-server-and-test": "^1.4.1"
+    "meteor-theme-hexo": "1.0.13"
   },
   "scripts": {
     "start": "npm run build && chexo apollo-hexo-config -- server",
     "build": "chexo apollo-hexo-config -- generate",
     "clean": "hexo clean",
-    "ci": "start-server-and-test start http-get://localhost:4000 test",
-    "test": "poke http://localhost:4000 --retry https://www.apollographql.com --shallow"
+    "test": "npm run clean; npm run build"
   }
 }


### PR DESCRIPTION
This partially reverts commit ca9a72ea296a90706c8bcaaf0d02a597ece5b07c from
apollographql/apollo-link#597, since the link checking is not working.

As discussed in other repositories, such as `apollo-client` and
`apollo-server`, it would be better to hoist this checking up to a higher,
site-wide location or introduce this functionality into our docs system
itself, rather than introducing it on individual repositories.

