### PR TITLE
toPromise: defer promise resolution until complete

### DIFF
--- a/packages/apollo-link/src/__tests__/linkUtils.ts
+++ b/packages/apollo-link/src/__tests__/linkUtils.ts
@@ -31,9 +31,26 @@ describe('Link utilities:', () => {
     };
     const error = new Error('I always error');
 
-    it('return next call as Promise resolution', () => {
+    it('return the value in next call as Promise resolution', () => {
       return makePromise(Observable.of(data)).then(result =>
         expect(data).toEqual(result),
+      );
+    });
+
+    it('resolve Promise in the complete call', () => {
+      let completeTick = false;
+      const observable = new Observable(observer => {
+        Promise.resolve()
+          .then(() => {
+            observer.next(null);
+          })
+          .then(() => {
+            completeTick = true;
+            observer.complete();
+          });
+      });
+      return makePromise(observable).then(result =>
+        expect(completeTick).toEqual(true),
       );
     });
 

--- a/packages/apollo-link/src/linkUtils.ts
+++ b/packages/apollo-link/src/linkUtils.ts
@@ -36,6 +36,7 @@ export function isTerminating(link: ApolloLink): boolean {
 
 export function toPromise<R>(observable: Observable<R>): Promise<R> {
   let completed = false;
+  let result: R;
   return new Promise<R>((resolve, reject) => {
     observable.subscribe({
       next: data => {
@@ -45,8 +46,11 @@ export function toPromise<R>(observable: Observable<R>): Promise<R> {
           );
         } else {
           completed = true;
-          resolve(data);
+          result = data;
         }
+      },
+      complete: () => {
+        resolve(result);
       },
       error: reject,
     });


### PR DESCRIPTION
Resolves #701.

This is a de-facto breaking change, so it can be deferred until the next major version.

TODO:

- [x] Make sure all of new logic is covered by tests and passes linting
- [ ] Update CHANGELOG.md with your change
