### PR TITLE
docs: Update blog URLs to reference blog.apollographql.com.

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -12,7 +12,7 @@ You can use Apollo Link with Apollo Client, `graphql-tools` schema stitching, Gr
 
 In a few words, Apollo Links are chainable "units" that you can snap together to define how each GraphQL request is handled by your GraphQL client. When you fire a GraphQL request, each Link's functionality is applied one after another. This allows you to control the request lifecycle in a way that makes sense for your application. For example, Links can provide [retrying](https://github.com/apollographql/apollo-link/tree/master/packages/apollo-link-retry), [polling](https://github.com/apollographql/apollo-link/tree/master/packages/apollo-link-polling), [batching](https://github.com/apollographql/apollo-link/tree/master/packages/apollo-link-batch), and more!
 
-If you're new to Apollo Link, you should read the [concepts guide](https://www.apollographql.com/docs/link/overview.html) which explains the motivation behind the package and its different pieces. The original [blog post](https://dev-blog.apollodata.com/apollo-link-the-modular-graphql-network-stack-3b6d5fcf9244) for the project is also a great first resource.
+If you're new to Apollo Link, you should read the [concepts guide](https://www.apollographql.com/docs/link/overview.html) which explains the motivation behind the package and its different pieces. The original [blog post](https://blog.apollographql.com/apollo-link-the-modular-graphql-network-stack-3b6d5fcf9244) for the project is also a great first resource.
 
 <h2 id="installation">Installation</h2>
 

--- a/docs/source/links/state.md
+++ b/docs/source/links/state.md
@@ -4,7 +4,7 @@ description: Manage your local data with Apollo Client
 ---
 
 [**Read the announcement post!
-🎉**](https://dev-blog.apollodata.com/the-future-of-state-management-dd410864cae2) |
+🎉**](https://blog.apollographql.com/the-future-of-state-management-dd410864cae2) |
 [**Video tutorial by Sara Vieira**](https://youtu.be/2RvRcnD8wHY) |
 [**apollo-link-state on GitHub**](https://github.com/apollographql/apollo-link-state)
 


### PR DESCRIPTION
This updates all blog URLs in the documentation to use blog.apollographql.com
as the domain, rather than dev-blog.apollodata.com.