### PR TITLE
Add `createBatchLink` to customise link creation

### DIFF
--- a/packages/apollo-link-batch-http/CHANGELOG.md
+++ b/packages/apollo-link-batch-http/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNext
 
+- Add `createBatchLink` option to customise link creation.
+
 ### 1.2.2
 - Update apollo-link [#559](https://github.com/apollographql/apollo-link/pull/559)
 - Check for signal already present on `fetchOptions` [#584](https://github.com/apollographql/apollo-link/pull/584)

--- a/packages/apollo-link-batch-http/src/__tests__/batchHttpLink.ts
+++ b/packages/apollo-link-batch-http/src/__tests__/batchHttpLink.ts
@@ -101,6 +101,22 @@ describe('BatchHttpLink', () => {
     expect(batchKeyArg()).toEqual(batchKey());
   });
 
+  it('can be configured to customize BatchLink creation', () => {
+    const LocalScopedLink = require('../batchHttpLink').BatchHttpLink;
+    const createBatchLink = jest.fn();
+
+    const batch = new LocalScopedLink({
+      batchInterval: 20,
+      batchMax: 20,
+      createBatchLink,
+    });
+
+    const { batchInterval, batchMax } = createBatchLink.mock.calls[0][0];
+
+    expect(batchInterval).toBe(20);
+    expect(batchMax).toBe(20);
+  });
+
   it('handles batched requests', done => {
     const link = new BatchHttpLink({
       uri: 'batch',


### PR DESCRIPTION
Hi! I’d like to propose a way to intercept batched operations before they’re sent.

One use case for this would be coalescing queries together that are being sent in the same batch if the graph structure allows it, and separating the results before returning them to whatever requested that data. Here’s a hypothetical example of two queries that could be merged:

```graphql
query DataForSomeComponent {
  someRange(start: 0, end: 3) {
    ...
  }
}

query DataForSomeOtherComponent {
  someRange(start: 1, end: 5) {
    ...
  }
}
```

Since the underlying `BatchLink` is created within `BatchHttpLink`, there’s currently no way to modify the array of batched operations before it’s sent.

I think the easiest solution to this would be to add an option that lets you use any link as long as it works like `BatchLink`, similar to how `fetch` is currently an option. This would allow wrapping the `batchHandler` option or swapping the entire link if more flexibility is required.

Let me know what you think!

<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Make sure all of new logic is covered by tests and passes linting
- [x] Update CHANGELOG.md with your change

**Pull Request Labels**

<!--
While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [x] feature
- [ ] blocking
- [ ] docs

<!--
To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->
