### PR TITLE
Update dependency @types/graphql to v0.13.4

### DIFF
--- a/packages/apollo-link-batch-http/package.json
+++ b/packages/apollo-link-batch-http/package.json
@@ -46,7 +46,7 @@
     "graphql": "^0.11.0 || ^0.12.3 || ^0.13.0"
   },
   "devDependencies": {
-    "@types/graphql": "0.12.6",
+    "@types/graphql": "0.13.3",
     "@types/jest": "22.2.3",
     "browserify": "16.2.2",
     "fetch-mock": "6.5.2",

--- a/packages/apollo-link-batch-http/package.json
+++ b/packages/apollo-link-batch-http/package.json
@@ -46,7 +46,7 @@
     "graphql": "^0.11.0 || ^0.12.3 || ^0.13.0"
   },
   "devDependencies": {
-    "@types/graphql": "0.13.3",
+    "@types/graphql": "0.13.4",
     "@types/jest": "22.2.3",
     "browserify": "16.2.2",
     "fetch-mock": "6.5.2",

--- a/packages/apollo-link-batch/package.json
+++ b/packages/apollo-link-batch/package.json
@@ -41,7 +41,7 @@
     "apollo-link": "^1.2.2"
   },
   "devDependencies": {
-    "@types/graphql": "0.12.6",
+    "@types/graphql": "0.13.3",
     "@types/jest": "22.2.3",
     "browserify": "16.2.2",
     "fetch-mock": "6.5.2",

--- a/packages/apollo-link-batch/package.json
+++ b/packages/apollo-link-batch/package.json
@@ -41,7 +41,7 @@
     "apollo-link": "^1.2.2"
   },
   "devDependencies": {
-    "@types/graphql": "0.13.3",
+    "@types/graphql": "0.13.4",
     "@types/jest": "22.2.3",
     "browserify": "16.2.2",
     "fetch-mock": "6.5.2",

--- a/packages/apollo-link-context/package.json
+++ b/packages/apollo-link-context/package.json
@@ -35,7 +35,7 @@
     "apollo-link": "^1.2.2"
   },
   "devDependencies": {
-    "@types/graphql": "0.12.6",
+    "@types/graphql": "0.13.3",
     "@types/jest": "22.2.3",
     "browserify": "16.2.2",
     "graphql": "0.13.2",

--- a/packages/apollo-link-context/package.json
+++ b/packages/apollo-link-context/package.json
@@ -35,7 +35,7 @@
     "apollo-link": "^1.2.2"
   },
   "devDependencies": {
-    "@types/graphql": "0.13.3",
+    "@types/graphql": "0.13.4",
     "@types/jest": "22.2.3",
     "browserify": "16.2.2",
     "graphql": "0.13.2",

--- a/packages/apollo-link-dedup/package.json
+++ b/packages/apollo-link-dedup/package.json
@@ -41,7 +41,7 @@
     "apollo-link": "^1.2.2"
   },
   "devDependencies": {
-    "@types/graphql": "0.12.6",
+    "@types/graphql": "0.13.3",
     "@types/jest": "22.2.3",
     "browserify": "16.2.2",
     "graphql": "0.13.2",

--- a/packages/apollo-link-dedup/package.json
+++ b/packages/apollo-link-dedup/package.json
@@ -41,7 +41,7 @@
     "apollo-link": "^1.2.2"
   },
   "devDependencies": {
-    "@types/graphql": "0.13.3",
+    "@types/graphql": "0.13.4",
     "@types/jest": "22.2.3",
     "browserify": "16.2.2",
     "graphql": "0.13.2",

--- a/packages/apollo-link-error/CHANGELOG.md
+++ b/packages/apollo-link-error/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Update types to be compatible with `@types/graphql@0.13.3`
 
 ### 1.1.0
 - Pass `forward` into error handler for ErrorLink to support retrying a failed request 

--- a/packages/apollo-link-error/package.json
+++ b/packages/apollo-link-error/package.json
@@ -35,7 +35,7 @@
     "apollo-link": "^1.2.2"
   },
   "devDependencies": {
-    "@types/graphql": "0.12.6",
+    "@types/graphql": "0.13.3",
     "@types/jest": "22.2.3",
     "browserify": "16.2.2",
     "graphql": "0.13.2",

--- a/packages/apollo-link-error/package.json
+++ b/packages/apollo-link-error/package.json
@@ -35,7 +35,7 @@
     "apollo-link": "^1.2.2"
   },
   "devDependencies": {
-    "@types/graphql": "0.13.3",
+    "@types/graphql": "0.13.4",
     "@types/jest": "22.2.3",
     "browserify": "16.2.2",
     "graphql": "0.13.2",

--- a/packages/apollo-link-error/src/index.ts
+++ b/packages/apollo-link-error/src/index.ts
@@ -8,7 +8,7 @@ import {
 import { GraphQLError, ExecutionResult } from 'graphql';
 
 export interface ErrorResponse {
-  graphQLErrors?: GraphQLError[];
+  graphQLErrors?: ReadonlyArray<GraphQLError>;
   networkError?: Error;
   response?: ExecutionResult;
   operation: Operation;

--- a/packages/apollo-link-http-common/package.json
+++ b/packages/apollo-link-http-common/package.json
@@ -35,7 +35,7 @@
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0"
   },
   "devDependencies": {
-    "@types/graphql": "0.12.6",
+    "@types/graphql": "0.13.3",
     "@types/jest": "22.2.3",
     "browserify": "16.2.2",
     "fetch-mock": "6.5.2",

--- a/packages/apollo-link-http-common/package.json
+++ b/packages/apollo-link-http-common/package.json
@@ -35,7 +35,7 @@
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0"
   },
   "devDependencies": {
-    "@types/graphql": "0.13.3",
+    "@types/graphql": "0.13.4",
     "@types/jest": "22.2.3",
     "browserify": "16.2.2",
     "fetch-mock": "6.5.2",

--- a/packages/apollo-link-http/package.json
+++ b/packages/apollo-link-http/package.json
@@ -46,7 +46,7 @@
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0"
   },
   "devDependencies": {
-    "@types/graphql": "0.12.6",
+    "@types/graphql": "0.13.3",
     "@types/jest": "22.2.3",
     "apollo-fetch": "0.7.0",
     "browserify": "16.2.2",

--- a/packages/apollo-link-http/package.json
+++ b/packages/apollo-link-http/package.json
@@ -46,7 +46,7 @@
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0"
   },
   "devDependencies": {
-    "@types/graphql": "0.13.3",
+    "@types/graphql": "0.13.4",
     "@types/jest": "22.2.3",
     "apollo-fetch": "0.7.0",
     "browserify": "16.2.2",

--- a/packages/apollo-link-polling/package.json
+++ b/packages/apollo-link-polling/package.json
@@ -43,7 +43,7 @@
     "apollo-link": "^1.2.2"
   },
   "devDependencies": {
-    "@types/graphql": "0.12.6",
+    "@types/graphql": "0.13.3",
     "@types/jest": "22.2.3",
     "browserify": "16.2.2",
     "graphql": "0.13.2",

--- a/packages/apollo-link-polling/package.json
+++ b/packages/apollo-link-polling/package.json
@@ -43,7 +43,7 @@
     "apollo-link": "^1.2.2"
   },
   "devDependencies": {
-    "@types/graphql": "0.13.3",
+    "@types/graphql": "0.13.4",
     "@types/jest": "22.2.3",
     "browserify": "16.2.2",
     "graphql": "0.13.2",

--- a/packages/apollo-link-retry/package.json
+++ b/packages/apollo-link-retry/package.json
@@ -42,7 +42,7 @@
     "apollo-link": "^1.2.2"
   },
   "devDependencies": {
-    "@types/graphql": "0.12.6",
+    "@types/graphql": "0.13.3",
     "@types/jest": "22.2.3",
     "browserify": "16.2.2",
     "graphql": "0.13.2",

--- a/packages/apollo-link-retry/package.json
+++ b/packages/apollo-link-retry/package.json
@@ -42,7 +42,7 @@
     "apollo-link": "^1.2.2"
   },
   "devDependencies": {
-    "@types/graphql": "0.13.3",
+    "@types/graphql": "0.13.4",
     "@types/jest": "22.2.3",
     "browserify": "16.2.2",
     "graphql": "0.13.2",

--- a/packages/apollo-link-schema/package.json
+++ b/packages/apollo-link-schema/package.json
@@ -46,7 +46,7 @@
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0"
   },
   "devDependencies": {
-    "@types/graphql": "0.12.6",
+    "@types/graphql": "0.13.3",
     "@types/jest": "22.2.3",
     "browserify": "16.2.2",
     "graphql": "0.13.2",

--- a/packages/apollo-link-schema/package.json
+++ b/packages/apollo-link-schema/package.json
@@ -46,7 +46,7 @@
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0"
   },
   "devDependencies": {
-    "@types/graphql": "0.13.3",
+    "@types/graphql": "0.13.4",
     "@types/jest": "22.2.3",
     "browserify": "16.2.2",
     "graphql": "0.13.2",

--- a/packages/apollo-link-ws/package.json
+++ b/packages/apollo-link-ws/package.json
@@ -44,7 +44,7 @@
     "subscriptions-transport-ws": "^0.9.0"
   },
   "devDependencies": {
-    "@types/graphql": "0.12.6",
+    "@types/graphql": "0.13.3",
     "@types/jest": "22.2.3",
     "browserify": "16.2.2",
     "graphql": "0.13.2",

--- a/packages/apollo-link-ws/package.json
+++ b/packages/apollo-link-ws/package.json
@@ -44,7 +44,7 @@
     "subscriptions-transport-ws": "^0.9.0"
   },
   "devDependencies": {
-    "@types/graphql": "0.13.3",
+    "@types/graphql": "0.13.4",
     "@types/jest": "22.2.3",
     "browserify": "16.2.2",
     "graphql": "0.13.2",

--- a/packages/apollo-link/package.json
+++ b/packages/apollo-link/package.json
@@ -38,7 +38,7 @@
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
-    "@types/graphql": "0.12.6",
+    "@types/graphql": "0.13.3",
     "apollo-utilities": "^1.0.0",
     "zen-observable-ts": "^0.8.9"
   },

--- a/packages/apollo-link/package.json
+++ b/packages/apollo-link/package.json
@@ -38,7 +38,7 @@
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
-    "@types/graphql": "0.13.3",
+    "@types/graphql": "0.13.4",
     "apollo-utilities": "^1.0.0",
     "zen-observable-ts": "^0.8.9"
   },


### PR DESCRIPTION
This updates `@types/graphql` to 0.13.3 as done by @renovate-bot and fixes tests that broke from that update. It would still be better if `@types/graphql` were not a dependency of `apollo-link` (see discussion in #634).

This resolves a type error in apollo-link-error resulting from upgrading `@types/graphql` to 0.13.3 as introduced by #579.

