### PR TITLE
Fix the typing of data attribute in FetchResult

### DIFF
--- a/packages/apollo-link/CHANGELOG.md
+++ b/packages/apollo-link/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Fix the typing of data attribute in FetchResult [PR#783](https://github.com/apollographql/apollo-link/pull/783)
 
 ### 1.2.2
 - Update apollo-link [#559](https://github.com/apollographql/apollo-link/pull/559)

--- a/packages/apollo-link/src/types.ts
+++ b/packages/apollo-link/src/types.ts
@@ -21,9 +21,11 @@ export interface Operation {
 }
 
 export type FetchResult<
+  T = Record<string, any>,
   C = Record<string, any>,
   E = Record<string, any>
 > = ExecutionResult & {
+  data?: T;
   extensions?: E;
   context?: C;
 };


### PR DESCRIPTION
When invoking a mutation directly via `apollo-client`, it returns a [`FetchResult<T>`](https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/ApolloClient.ts#L271)

However the first argument is not used for the `data` attribute, instead it types the `context` attribute.  
So with this change the first argument instead specifies the type of `data`, instead of `context`.

/label enhancement
