### PR TITLE
Expose generics from graphql ExecutionResult on FetchResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## YYYY-MM-DD
 
+### apollo-link
+
+- Expose generics from graphql `ExecutionResult` on `FetchResult`.  <br/>
+  [@rosskevin](https://github.com/rosskevin) in [#804](https://github.com/apollographql/apollo-link/pull/804)
+
 ### apollo-link-batch
 
 - Move the setting of the raw response in the `context` to 

--- a/packages/apollo-link/CHANGELOG.md
+++ b/packages/apollo-link/CHANGELOG.md
@@ -12,7 +12,7 @@ the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-link/blob
 - No changes
 
 ### 1.2.3
-- Added `graphql` 14 to peer and dev deps; Updated `@types/graphql` to 14 <br/>
+- Added `graphql` 14 to peer and dev deps; Updated `@types/graphql` to 14<br/>
   [@hwillson](http://github.com/hwillson) in [#789](https://github.com/apollographql/apollo-link/pull/789)
 
 ### 1.2.2

--- a/packages/apollo-link/CHANGELOG.md
+++ b/packages/apollo-link/CHANGELOG.md
@@ -12,7 +12,7 @@ the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-link/blob
 - No changes
 
 ### 1.2.3
-- Added `graphql` 14 to peer and dev deps; Updated `@types/graphql` to 14<br/>
+- Added `graphql` 14 to peer and dev deps; Updated `@types/graphql` to 14  <br/>
   [@hwillson](http://github.com/hwillson) in [#789](https://github.com/apollographql/apollo-link/pull/789)
 
 ### 1.2.2

--- a/packages/apollo-link/CHANGELOG.md
+++ b/packages/apollo-link/CHANGELOG.md
@@ -1,46 +1,64 @@
 # Change log
 
+### next
+
+- Update the generic signature on `FetchResult` to expose strong data typing added to [`@types/graphql`](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/deb7d8beaff5d43da749c5bc0f2020cdcaaabb6b#diff-1a92e4f388a3da0eb35da5e193f02172)
+
 ### 1.2.3
-- Added `graphql` 14 to peer and dev deps; Updated `@types/graphql` to 14  <br/>
+
+- Added `graphql` 14 to peer and dev deps; Updated `@types/graphql` to 14 <br/>
   [@hwillson](http://github.com/hwillson) in [#789](https://github.com/apollographql/apollo-link/pull/789)
 
 ### 1.2.2
+
 - Update apollo-link [#559](https://github.com/apollographql/apollo-link/pull/559)
 - export graphql types and add @types/graphql as a regular dependency [PR#576](https://github.com/apollographql/apollo-link/pull/576)
 - moved @types/node to dev dependencies in package.josn to avoid collisions with other projects. [PR#540](https://github.com/apollographql/apollo-link/pull/540)
 
 ### 1.2.1
+
 - update apollo link with zen-observable-ts to remove import issues [PR#515](https://github.com/apollographql/apollo-link/pull/515)
 
 ### 1.2.0
+
 - Add `fromError` Observable helper
 - change import method of zen-observable for rollup compat
 
 ### 1.1.0
+
 - Expose `#execute` on ApolloLink as static
 
 ### 1.0.7
+
 - Update to graphql@0.12
 
 ### 1.0.6
+
 - update rollup
 
 ### 1.0.5
+
 - fix bug where context wasn't merged when setting it
 
 ### 1.0.4
+
 - export link util helpers
 
 ### 1.0.3
+
 - removed requiring query on initial execution check
 - moved to move efficent rollup build
 
 ### 1.0.1, 1.0.2
+
 <!-- never published as latest -->
+
 - preleases for dev tool integation
 
 ### 0.8.0
+
 - added support for `extensions` on an operation
 
 ### 0.7.0
+
 - new operation API and start of changelog

--- a/packages/apollo-link/CHANGELOG.md
+++ b/packages/apollo-link/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change log
 
+----
+
 **NOTE:** This changelog is no longer maintained. Changes are now tracked in
 the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-link/blob/master/CHANGELOG.md).
 
@@ -10,60 +12,46 @@ the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-link/blob
 - No changes
 
 ### 1.2.3
-
 - Added `graphql` 14 to peer and dev deps; Updated `@types/graphql` to 14 <br/>
   [@hwillson](http://github.com/hwillson) in [#789](https://github.com/apollographql/apollo-link/pull/789)
 
 ### 1.2.2
-
 - Update apollo-link [#559](https://github.com/apollographql/apollo-link/pull/559)
 - export graphql types and add @types/graphql as a regular dependency [PR#576](https://github.com/apollographql/apollo-link/pull/576)
 - moved @types/node to dev dependencies in package.josn to avoid collisions with other projects. [PR#540](https://github.com/apollographql/apollo-link/pull/540)
 
 ### 1.2.1
-
 - update apollo link with zen-observable-ts to remove import issues [PR#515](https://github.com/apollographql/apollo-link/pull/515)
 
 ### 1.2.0
-
 - Add `fromError` Observable helper
 - change import method of zen-observable for rollup compat
 
 ### 1.1.0
-
 - Expose `#execute` on ApolloLink as static
 
 ### 1.0.7
-
 - Update to graphql@0.12
 
 ### 1.0.6
-
 - update rollup
 
 ### 1.0.5
-
 - fix bug where context wasn't merged when setting it
 
 ### 1.0.4
-
 - export link util helpers
 
 ### 1.0.3
-
 - removed requiring query on initial execution check
 - moved to move efficent rollup build
 
 ### 1.0.1, 1.0.2
-
 <!-- never published as latest -->
-
 - preleases for dev tool integation
 
 ### 0.8.0
-
 - added support for `extensions` on an operation
 
 ### 0.7.0
-
 - new operation API and start of changelog

--- a/packages/apollo-link/src/types.ts
+++ b/packages/apollo-link/src/types.ts
@@ -21,9 +21,10 @@ export interface Operation {
 }
 
 export type FetchResult<
+  TData = { [key: string]: any },
   C = Record<string, any>,
   E = Record<string, any>
-> = ExecutionResult & {
+> = ExecutionResult<TData> & {
   extensions?: E;
   context?: C;
 };


### PR DESCRIPTION
TODO:

- [ ] Make sure all of new logic is covered by tests and passes linting
- [x] Update CHANGELOG.md with your change

**Pull Request Labels**

<!--
While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [ ] feature
- [x] blocking
- [ ] docs


Related to Jul 3 change in `@types/graphql`, update the `FetchResult` generics to strongly type the data.  I added `blocking` because [it prevents strong typing in usage of `apollo-client`](https://github.com/apollographql/apollo-client/issues/2795#issuecomment-424124181).

See: 
- https://github.com/DefinitelyTyped/DefinitelyTyped/commit/deb7d8beaff5d43da749c5bc0f2020cdcaaabb6b#diff-1a92e4f388a3da0eb35da5e193f02172
- https://github.com/apollographql/apollo-client/issues/2795#issuecomment-424124181