### PR TITLE
fix(websocket-client): use `url` client property if `uri` doesn't exist

### DIFF
--- a/packages/apollo-link-ws/CHANGELOG.md
+++ b/packages/apollo-link-ws/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+### 1.0.10
+- Fixed an issue where incorrect peer dependency versions caused a crash on
+link creation
+
 ### 1.0.9
 - Added `graphql` 14 to peer and dev deps; Updated `@types/graphql` to 14  <br/>
   [@hwillson](http://github.com/hwillson) in [#789](https://github.com/apollographql/apollo-link/pull/789)

--- a/packages/apollo-link-ws/src/webSocketLink.ts
+++ b/packages/apollo-link-ws/src/webSocketLink.ts
@@ -11,6 +11,7 @@ export namespace WebSocketLink {
      * The endpoint to connect to.
      */
     uri: string;
+    url: string;
 
     /**
      * Options to pass when constructing the subscription client.
@@ -39,7 +40,7 @@ export class WebSocketLink extends ApolloLink {
       this.subscriptionClient = paramsOrClient;
     } else {
       this.subscriptionClient = new SubscriptionClient(
-        paramsOrClient.uri,
+        paramsOrClient.uri || paramsOrClient.url,
         paramsOrClient.options,
         paramsOrClient.webSocketImpl,
       );


### PR DESCRIPTION
SubscriptionClient throws an error if the first argument is undefined, breaking the booting process of the whole application this link is being created in.  

This likely occurs because users might have incorrect versions of the `subscriptions-transport-ws` peer dependency, which would cause either the `uri` or the `url` property to become undefined.  

fixes #773 

<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Make sure all of new logic is covered by tests and passes linting
> Covered by the `constructs` test in `src/__tests__/webSocketLink.ts`
- [x] Update CHANGELOG.md with your change

**Pull Request Labels**

<!--
While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [ ] feature
- [ ] blocking
- [ ] docs

<!--
To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

/label bugfix
