### PR TITLE
Fix missing genenic type in types definition

### DIFF
--- a/packages/apollo-link/src/types.ts
+++ b/packages/apollo-link/src/types.ts
@@ -23,7 +23,7 @@ export interface Operation {
 export type FetchResult<
   C = Record<string, any>,
   E = Record<string, any>
-> = ExecutionResult & {
+> = ExecutionResult<C> & {
   extensions?: E;
   context?: C;
 };


### PR DESCRIPTION
```Typescript
apolloClient.mutate<T>().then(result => result)
```
has no type hint on `result.data` before fix.

<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Make sure all of new logic is covered by tests and passes linting
- [ ] Update CHANGELOG.md with your change

**Pull Request Labels**

<!--
While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [ ] feature
- [ ] blocking
- [ ] docs

<!--
To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->
