### PR TITLE
[apollo-link] Make network error a Response in ErrorResponse

### DIFF
--- a/packages/apollo-link-error/src/index.ts
+++ b/packages/apollo-link-error/src/index.ts
@@ -11,7 +11,7 @@ import { GraphQLError, ExecutionResult } from 'graphql';
 
 export interface ErrorResponse {
   graphQLErrors?: ReadonlyArray<GraphQLError>;
-  networkError?: Error;
+  networkError?: Response;
   response?: ExecutionResult;
   operation: Operation;
   forward: NextLink;


### PR DESCRIPTION
Network error is a `Response` object with members such as `statusText` and `redirected`


This is how *I* see it in our runtime. Can you confirm if this is the right change? 