### PR TITLE
Fix installation directions

### DIFF
--- a/docs/source/links/rest.md
+++ b/docs/source/links/rest.md
@@ -28,10 +28,10 @@ For an apollo client to work, you need a link and a cache, [more info here](/doc
 npm install --save apollo-cache-inmemory
 ```
 
-Then it is time to install our link:
+Then it is time to install our link and its `peerDependencies`:
 
 ```bash
-npm install apollo-link-rest --save
+npm install apollo-link-rest apollo-link graphql graphql-anywhere--save
 ```
 
 After this, you are ready to setup your apollo client:


### PR DESCRIPTION
This PR fixes the `link-rest` docs which don't list the required peerDepencendies, causing issues like https://github.com/nihakue/apollo-rest-link-minimal-repro

The installation directions are correct in https://github.com/apollographql/apollo-link-rest#installation

- [ ] feature
- [ ] blocking
- [x] docs

