### PR TITLE
Pull request cloned from PR #814

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "name": "chrispage1 apollo-link clone",
   "license": "MIT",
   "scripts": {
     "bootstrap": "lerna bootstrap",

--- a/packages/apollo-link-batch-http/CHANGELOG.md
+++ b/packages/apollo-link-batch-http/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+### 1.2.4
+- Fixed raw response not being set on context. Headers can now be retrieved
+
 ### 1.2.3
 - Added `graphql` 14 to peer and dev deps; Updated `@types/graphql` to 14  <br/>
   [@hwillson](http://github.com/hwillson) in [#789](https://github.com/apollographql/apollo-link/pull/789)

--- a/packages/apollo-link-batch-http/src/__tests__/batchHttpLink.ts
+++ b/packages/apollo-link-batch-http/src/__tests__/batchHttpLink.ts
@@ -42,12 +42,20 @@ describe('BatchHttpLink', () => {
     jest.resetModules();
   });
 
+  const headers = { cookie: 'monster' };
   const data = { data: { hello: 'world' } };
   const data2 = { data: { hello: 'everyone' } };
   const roflData = { data: { haha: 'hehe' } };
   const lawlData = { data: { tehe: 'haaa' } };
   const makePromise = res =>
-    new Promise((resolve, reject) => setTimeout(() => resolve(res)));
+      new Promise((resolve, reject) =>
+          setTimeout(() =>
+              resolve({
+                  headers,
+                  body: res,
+              }),
+          ),
+      );
 
   let subscriber;
 

--- a/packages/apollo-link-batch-http/src/batchHttpLink.ts
+++ b/packages/apollo-link-batch-http/src/batchHttpLink.ts
@@ -131,6 +131,11 @@ export class BatchHttpLink extends ApolloLink {
       return new Observable<FetchResult[]>(observer => {
         // the raw response is attached to the context in the BatchingLink
         fetcher(chosenURI, options)
+          .then(response => {
+              // attach the raw response to the contexts for usage
+              operations.forEach(operation => operation.setContext({ response }));
+              return response;
+          })
           .then(parseAndCheckHttpResponse(operations))
           .then(result => {
             // we have data and can send it to back up the link chain

--- a/packages/apollo-link-batch/src/__tests__/batchLink.ts
+++ b/packages/apollo-link-batch/src/__tests__/batchLink.ts
@@ -326,7 +326,6 @@ describe('OperationBatcher', () => {
     setTimeout(
       terminatingCheck(done, () => {
         expect(batcher.queuedRequests.get('')).toBeUndefined();
-        expect(operation.getContext()).toEqual({ response: { data } });
       }),
       20,
     );
@@ -382,9 +381,6 @@ describe('OperationBatcher', () => {
     setTimeout(
       terminatingCheck(done, () => {
         // The batch should've been fired by now.
-        expect(operation.getContext()).toEqual({ response: { data } });
-        expect(operation2.getContext()).toEqual({ response: { data: data2 } });
-        expect(operation3.getContext()).toEqual({ response: { data } });
         expect(batcher.queuedRequests.get('')).toBeUndefined();
       }),
       20,

--- a/packages/apollo-link-batch/src/batching.ts
+++ b/packages/apollo-link-batch/src/batching.ts
@@ -160,8 +160,6 @@ export class OperationBatcher {
         }
 
         results.forEach((result, index) => {
-          // attach the raw response to the context for usage
-          requests[index].setContext({ response: result });
           if (nexts[index]) {
             nexts[index].forEach(next => next(result));
           }

--- a/packages/apollo-link-http/CHANGELOG.md
+++ b/packages/apollo-link-http/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+### 1.5.6
+- Moved setting of response on context into apollo-link-batch-http
+
 ### 1.5.5
 - Added `graphql` 14 to peer and dev deps; Updated `@types/graphql` to 14  <br/>
   [@hwillson](http://github.com/hwillson) in [#789](https://github.com/apollographql/apollo-link/pull/789)

--- a/packages/apollo-link-http/src/__tests__/sharedHttpTests.ts
+++ b/packages/apollo-link-http/src/__tests__/sharedHttpTests.ts
@@ -567,6 +567,33 @@ export const sharedHttpTest = (
         }),
       );
     });
+
+      it('sets the raw response on context', done => {
+          const middleware = new ApolloLink((operation, forward) => {
+              return new Observable(ob => {
+                  const op = forward(operation);
+                  const sub = op.subscribe({
+                      next: ob.next.bind(ob),
+                      error: ob.error.bind(ob),
+                      complete: makeCallback(done, e => {
+                          expect(operation.getContext().response.headers.toBeDefined);
+                          ob.complete();
+                      }),
+                  });
+                  return () => {
+                      sub.unsubscribe();
+                  };
+              });
+          });
+          const link = middleware.concat(createLink({ uri: 'data', fetch }));
+          execute(link, { query: sampleQuery }).subscribe(
+              result => {
+                  done();
+              },
+              () => {},
+          );
+      });
+
   });
 
   describe('dev warnings', () => {


### PR DESCRIPTION
This is a direct clone of original PR #814 that didn't seem to be progressing. I am addressing the header feature as I'd appreciate having this functionality in a current project.

This allows headers to be retrieved when making a request via `apollo-link-batch-http` in exactly the same way that already exists in `apollo-link-http`. Sample code - 

````
let afterWare = new ApolloLink((operation, forward) => {
    return forward(operation).map(response => {

        // get our context, then headers
        const context = operation.getContext();
        const { response: { headers } } = context;
        
        // fix: retrieve headers after a request has been completed
        // from batch request so we can use them
        console.log(headers.get('X-Refresh-Token'));

        return response;
    });
});

// create our batch http link
let httpLink = new BatchHttpLink({
    uri: '/myEndpoint',
    transportBatching: true
});

// create our Apollo client
let apolloClient = new ApolloClient({
    shouldBatch: true,
    link: ApolloLink.from([ afterWare, httpLink ]),
    cache: cache,
    connectToDevTools: true,
});

````

See #231 #550, #631, #814 to name just a few!