### PR TITLE
Remove labels from GH templates since we're disabling Apollo Bot

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -23,18 +23,3 @@ Places to look for information include your browser console, server console, and
 example: A Codesandbox or GitHub repository that anyone can clone to observe the problem
 -->
 
-**Issue Labels**
-
-<!--
-While not necessary, you can help organize our issues by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
--->
-
-- [ ] has-reproduction
-- [ ] feature
-- [ ] docs
-- [ ] blocking
-- [ ] good first issue
-
-<!--
-To add a label not listed above, simply place `/label another-label-name` on a line by itself.
--->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,16 +10,3 @@ TODO:
 - [ ] Make sure all of new logic is covered by tests and passes linting
 - [ ] Update CHANGELOG.md with your change
 
-**Pull Request Labels**
-
-<!--
-While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
--->
-
-- [ ] feature
-- [ ] blocking
-- [ ] docs
-
-<!--
-To add a label not listed above, simply place `/label another-label-name` on a line by itself.
--->


### PR DESCRIPTION
Removing all mentions of labelling from this repos custom issue/PR templates (since we're no longer using Apollo Bot).