### PR TITLE
Add client awareness settings to request headers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "editor.tabSize": 2,
-  "editor.rulers": [140],
   "files.trimTrailingWhitespace": true,
   "files.insertFinalNewline": true,
   "files.exclude": {

--- a/packages/apollo-link-http/CHANGELOG.md
+++ b/packages/apollo-link-http/CHANGELOG.md
@@ -7,7 +7,7 @@
   to all outgoing requests. The header names used (`apollographql-client-name`
   and `apollographql-client-version`) line up with the associated Apollo Server
   changes made in https://github.com/apollographql/apollo-server/pull/1960.  <br/>
-  [@hwillson](http://github.com/hwillson) in [#TODO](https://github.com/apollographql/apollo-link/pull/)
+  [@hwillson](http://github.com/hwillson) in [#872](https://github.com/apollographql/apollo-link/pull/872)
 
 ### 1.5.5
 - Added `graphql` 14 to peer and dev deps; Updated `@types/graphql` to 14  <br/>

--- a/packages/apollo-link-http/CHANGELOG.md
+++ b/packages/apollo-link-http/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change log
 
+### vNext
+
+- If `name` or `version` client awareness settings are found in the
+  incoming `operation` `context`, they'll be extracted and added as headers
+  to all outgoing requests. The header names used (`apollographql-client-name`
+  and `apollographql-client-version`) line up with the associated Apollo Server
+  changes made in https://github.com/apollographql/apollo-server/pull/1960.  <br/>
+  [@hwillson](http://github.com/hwillson) in [#TODO](https://github.com/apollographql/apollo-link/pull/)
+
 ### 1.5.5
 - Added `graphql` 14 to peer and dev deps; Updated `@types/graphql` to 14  <br/>
   [@hwillson](http://github.com/hwillson) in [#789](https://github.com/apollographql/apollo-link/pull/789)

--- a/packages/apollo-link-http/src/__tests__/httpLink.ts
+++ b/packages/apollo-link-http/src/__tests__/httpLink.ts
@@ -183,6 +183,39 @@ describe('HttpLink', () => {
         }),
       );
     });
+
+    it('should add client awareness settings to request headers', done => {
+      const variables = { params: 'stub' };
+      const link = createHttpLink({
+        uri: 'http://data/',
+      });
+
+      const clientAwareness = {
+        name: 'Some Client Name',
+        version: '1.0.1',
+      };
+
+      execute(link, {
+        query: sampleQuery,
+        variables,
+        context: {
+          clientAwareness,
+        },
+      }).subscribe(
+        makeCallback(done, result => {
+          const [uri, options] = fetchMock.lastCall();
+          const { headers } = options;
+          expect(headers['apollographql-client-name']).toBeDefined();
+          expect(headers['apollographql-client-name']).toEqual(
+            clientAwareness.name,
+          );
+          expect(headers['apollographql-client-version']).toBeDefined();
+          expect(headers['apollographql-client-version']).toEqual(
+            clientAwareness.version,
+          );
+        }),
+      );
+    });
   });
 
   it("throws for GET if the variables can't be stringified", done => {

--- a/packages/apollo-link-http/src/httpLink.ts
+++ b/packages/apollo-link-http/src/httpLink.ts
@@ -63,13 +63,21 @@ export const createHttpLink = (linkOptions: HttpLink.Options = {}) => {
     let chosenURI = selectURI(operation, uri);
 
     const context = operation.getContext();
-    const contextHeaders = { ...context.headers };
 
+    // `apollographql-client-*` headers are automatically set if a
+    // `clientAwareness` object is found in the context. These headers are
+    // set first, followed by the rest of the headers pulled from
+    // `context.headers`. If desired, `apollographql-client-*` headers set by
+    // the `clientAwareness` object can be overridden by
+    // `apollographql-client-*` headers set in `context.headers`.
+    const clientAwarenessHeaders = {};
     if (context.clientAwareness) {
       const { name, version } = context.clientAwareness;
-      contextHeaders['apollographql-client-name'] = name;
-      contextHeaders['apollographql-client-version'] = version;
+      clientAwarenessHeaders['apollographql-client-name'] = name;
+      clientAwarenessHeaders['apollographql-client-version'] = version;
     }
+
+    const contextHeaders = { ...clientAwarenessHeaders, ...context.headers };
 
     const contextConfig = {
       http: context.http,

--- a/packages/apollo-link-http/src/httpLink.ts
+++ b/packages/apollo-link-http/src/httpLink.ts
@@ -63,12 +63,19 @@ export const createHttpLink = (linkOptions: HttpLink.Options = {}) => {
     let chosenURI = selectURI(operation, uri);
 
     const context = operation.getContext();
+    const contextHeaders = { ...context.headers };
+
+    if (context.clientAwareness) {
+      const { name, version } = context.clientAwareness;
+      contextHeaders['apollographql-client-name'] = name;
+      contextHeaders['apollographql-client-version'] = version;
+    }
 
     const contextConfig = {
       http: context.http,
       options: context.fetchOptions,
       credentials: context.credentials,
-      headers: context.headers,
+      headers: contextHeaders,
     };
 
     //uses fallback, link, and then context to build options


### PR DESCRIPTION
This PR modifies `apollo-link-http` such that if `name` or `version` client awareness settings are found in the incoming `operation` `context`, they'll be extracted and added as headers to all outgoing requests. The header names used (`apollographql-client-name` and `apollographql-client-version`) line up with the associated Apollo Server changes made in https://github.com/apollographql/apollo-server/pull/1960.

Associated Apollo Client PR: https://github.com/apollographql/apollo-client/pull/4154