### PR TITLE
Make sure empty client awareness headers aren't included

### DIFF
--- a/packages/apollo-link-http/CHANGELOG.md
+++ b/packages/apollo-link-http/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+### 1.5.7
+
+- Fix a bug where empty `apollographql-client-name` and
+  `apollographql-client-version` headers were being included with requests
+  when they weren't set in the `context` based `clientAwareness` object.  <br/>
+  [@hwillson](http://github.com/hwillson) in [#872](https://github.com/apollographql/apollo-link/pull/872)
+
 ### 1.5.6
 
 - If `name` or `version` client awareness settings are found in the

--- a/packages/apollo-link-http/src/__tests__/httpLink.ts
+++ b/packages/apollo-link-http/src/__tests__/httpLink.ts
@@ -216,6 +216,32 @@ describe('HttpLink', () => {
         }),
       );
     });
+
+    it('should not add empty client awareness settings to request headers', done => {
+      const variables = { params: 'stub' };
+      const link = createHttpLink({
+        uri: 'http://data/',
+      });
+
+      const hasOwn = Object.prototype.hasOwnProperty;
+      const clientAwareness = {};
+      execute(link, {
+        query: sampleQuery,
+        variables,
+        context: {
+          clientAwareness,
+        },
+      }).subscribe(
+        makeCallback(done, result => {
+          const [uri, options] = fetchMock.lastCall();
+          const { headers } = options;
+          expect(hasOwn.call(headers, 'apollographql-client-name')).toBe(false);
+          expect(hasOwn.call(headers, 'apollographql-client-version')).toBe(
+            false,
+          );
+        }),
+      );
+    });
   });
 
   it("throws for GET if the variables can't be stringified", done => {

--- a/packages/apollo-link-http/src/httpLink.ts
+++ b/packages/apollo-link-http/src/httpLink.ts
@@ -73,8 +73,12 @@ export const createHttpLink = (linkOptions: HttpLink.Options = {}) => {
     const clientAwarenessHeaders = {};
     if (context.clientAwareness) {
       const { name, version } = context.clientAwareness;
-      clientAwarenessHeaders['apollographql-client-name'] = name;
-      clientAwarenessHeaders['apollographql-client-version'] = version;
+      if (name) {
+        clientAwarenessHeaders['apollographql-client-name'] = name;
+      }
+      if (version) {
+        clientAwarenessHeaders['apollographql-client-version'] = version;
+      }
     }
 
     const contextHeaders = { ...clientAwarenessHeaders, ...context.headers };


### PR DESCRIPTION
This PR makes sure empty `apollographql-client-name` and `apollographql-client-version` headers aren't included with requests when they aren't set in the context based `clientAwareness` object.

Fixes https://github.com/apollographql/apollo-client/issues/4164#issuecomment-440911776.
