### PR TITLE
Deprecate individual package changelogs; Placehold root log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+**Note:** This is a cumulative changelog that outlines all of the Apollo Link project child package changes that were bundled into a release on a specific day.
+
+## YYYY-MM-DD
+
+### package1
+
+### package2
+
+...

--- a/packages/apollo-link-batch-http/CHANGELOG.md
+++ b/packages/apollo-link-batch-http/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+----
+
+**NOTE:** This changelog is no longer maintained. Changes are now tracked in
+the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-link/blob/master/CHANGELOG.md).
+
+----
+
 ### 1.2.4
 
 - No changes

--- a/packages/apollo-link-batch/CHANGELOG.md
+++ b/packages/apollo-link-batch/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+----
+
+**NOTE:** This changelog is no longer maintained. Changes are now tracked in
+the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-link/blob/master/CHANGELOG.md).
+
+----
+
 ### 1.1.5
 
 - No changes

--- a/packages/apollo-link-context/CHANGELOG.md
+++ b/packages/apollo-link-context/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+----
+
+**NOTE:** This changelog is no longer maintained. Changes are now tracked in
+the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-link/blob/master/CHANGELOG.md).
+
+----
+
 ### 1.0.10
 
 - No changes

--- a/packages/apollo-link-dedup/CHANGELOG.md
+++ b/packages/apollo-link-dedup/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+----
+
+**NOTE:** This changelog is no longer maintained. Changes are now tracked in
+the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-link/blob/master/CHANGELOG.md).
+
+----
+
 ### 1.0.11
 
 - No changes

--- a/packages/apollo-link-error/CHANGELOG.md
+++ b/packages/apollo-link-error/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+----
+
+**NOTE:** This changelog is no longer maintained. Changes are now tracked in
+the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-link/blob/master/CHANGELOG.md).
+
+----
+
 ### 1.1.2
 
 - No changes

--- a/packages/apollo-link-http-common/CHANGELOG.md
+++ b/packages/apollo-link-http-common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+----
+
+**NOTE:** This changelog is no longer maintained. Changes are now tracked in
+the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-link/blob/master/CHANGELOG.md).
+
+----
+
 ### 0.2.6
 
 - No changes

--- a/packages/apollo-link-http/CHANGELOG.md
+++ b/packages/apollo-link-http/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+----
+
+**NOTE:** This changelog is no longer maintained. Changes are now tracked in
+the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-link/blob/master/CHANGELOG.md).
+
+----
+
 ### 1.5.7
 
 - Fix a bug where empty `apollographql-client-name` and

--- a/packages/apollo-link-polling/CHANGELOG.md
+++ b/packages/apollo-link-polling/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+----
+
+**NOTE:** This changelog is no longer maintained. Changes are now tracked in
+the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-link/blob/master/CHANGELOG.md).
+
+----
+
 ### 1.0.10
 
 - No changes

--- a/packages/apollo-link-retry/CHANGELOG.md
+++ b/packages/apollo-link-retry/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+----
+
+**NOTE:** This changelog is no longer maintained. Changes are now tracked in
+the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-link/blob/master/CHANGELOG.md).
+
+----
+
 ### 2.2.6
 
 - No changes

--- a/packages/apollo-link-schema/CHANGELOG.md
+++ b/packages/apollo-link-schema/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+----
+
+**NOTE:** This changelog is no longer maintained. Changes are now tracked in
+the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-link/blob/master/CHANGELOG.md).
+
+----
+
 ### 1.1.2
 
 - No changes

--- a/packages/apollo-link-ws/CHANGELOG.md
+++ b/packages/apollo-link-ws/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+----
+
+**NOTE:** This changelog is no longer maintained. Changes are now tracked in
+the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-link/blob/master/CHANGELOG.md).
+
+----
+
 ### 1.0.10
 
 - No changes

--- a/packages/apollo-link/CHANGELOG.md
+++ b/packages/apollo-link/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+----
+
+**NOTE:** This changelog is no longer maintained. Changes are now tracked in
+the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-link/blob/master/CHANGELOG.md).
+
+----
+
 ### 1.2.4
 
 - No changes

--- a/packages/zen-observable-ts/CHANGELOG.md
+++ b/packages/zen-observable-ts/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+----
+
+**NOTE:** This changelog is no longer maintained. Changes are now tracked in
+the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-link/blob/master/CHANGELOG.md).
+
+----
+
 ### 0.8.11
 
 - No changes


### PR DESCRIPTION
We're moving towards tracking all sub-package changes in a single top level cumulative changelog.