### PR TITLE
Sync apollo-link-rest 0.7.0 docs!

### DIFF
--- a/docs/source/links/rest.md
+++ b/docs/source/links/rest.md
@@ -92,7 +92,7 @@ Construction of `RestLink` takes an options object to customize the behavior of 
 * `typePatcher: /map-of-functions/`: _optional_ Structure to allow you to specify the `__typename` when you have nested objects in your REST response!
 * `defaultSerializer /function/`: _optional_ function that will be used by the `RestLink` as the default serializer when no `bodySerializer` is defined for a `@rest` call. The function will also be passed the current `Header` set, which can be updated before the request is sent to `fetch`. Default method uses `JSON.stringify` and sets the `Content-Type` to `application/json`.
 * `bodySerializers: /map-of-functions/`: _optional_ Structure to allow the definition of alternative serializers, which can then be specified by their key.
-
+* `responseTransformer?: /function/`: _optional_ Apollo expects a record response to return a root object, and a collection of records response to return an array of objects. Use this function to structure the response into the format Apollo expects if your response data is structured differently.
 
 
 <h3 id="options.endpoints">Multiple endpoints</h3>
@@ -252,6 +252,93 @@ To make this work you should try to pick one strategy, and stick with it -- eith
 
 This is tracked in [Issue #112](https://github.com/apollographql/apollo-link-rest/issues/112)
 
+<h3 id="options.responseTransformer">Response transforming</h3>
+
+By default, Apollo expects an object at the root for record requests, and an array of objects at the root for collection requests. For example, if fetching a user by ID (`/users/1`), the following response is expected.
+
+```json
+{
+  "id": 1,
+  "name": "Apollo"
+}
+```
+
+And when fetching for a list of users (`/users`), the following response is expected.
+
+```json
+[
+  {
+    "id": 1,
+    "name": "Apollo"
+  },
+  {
+    "id": 2,
+    "name": "Starman"
+  }
+]
+```
+
+If the structure of your API responses differs than what Apollo expects, you can define a `responseTransformer` in the client. This function receives the response object as the 1st argument, and the current `typeName` as the 2nd argument. It should return a `Promise` as it will be responsible for reading the response stream by calling one of `json()`, `text()` etc.
+
+For instance if the record is not at the root level:
+
+```json
+{
+  "meta": {},
+  "data": [
+    {
+      "id": 1,
+      "name": "Apollo"
+    },
+    {
+      "id": 2,
+      "name": "Starman"
+    }
+  ]
+}
+```
+
+The following transformer could be used to support it:
+
+
+```js
+const link = new RestLink({
+  uri: '/api',
+  responseTransformer: async response => response.json().then(({data}) => data),
+});
+```
+
+Plaintext, or XML, or otherwise-encoded responses can be handled by manually parsing and converting them to JSON (using the previously described format that Apollo expects):
+
+```js
+const link = new RestLink({
+  uri: '/xmlApi',
+  responseTransformer: async response => response.text().then(text => parseXmlResponseToJson(text)),
+});
+
+```
+
+<h3 id="options.responseTransformer.endpoints">Custom endpoint responses</h3>
+
+The client level `responseTransformer` applies for all responses, across all URIs and endpoints. If you need a custom `responseTransformer` per endpoint, you can define an object of options for that specific endpoint.
+
+```js
+const link = new RestLink({
+  endpoints: {
+    v1: {
+      uri: '/v1',
+      responseTransformer: async response => response.data,
+    },
+    v2: {
+      uri: '/v2',
+      responseTransformer: async (response, typeName) => response[typeName],
+    },
+  },
+});
+```
+
+> When using the object form, the `uri` field is required.
+
 <h3 id=options.example>Complete options</h3>
 
 Here is one way you might customize `RestLink`:
@@ -259,7 +346,7 @@ Here is one way you might customize `RestLink`:
 ```js
   import fetch from 'node-fetch';
   import * as camelCase from 'camelcase';
-  import * as snake_case from 'snack-case';
+  import * as snake_case from 'snake-case';
 
   const link = new RestLink({
     endpoints: { github: 'github.com' },
@@ -269,7 +356,7 @@ Here is one way you might customize `RestLink`:
       "Content-Type": "application/json"
     },
     credentials: "same-origin",
-    fieldNameNormalizer: (key: string) => camelCase(name),
+    fieldNameNormalizer: (key: string) => camelCase(key),
     fieldNameDenormalizer: (key: string) => snake_case(key),
     typePatcher: {
       Post: ()=> {
@@ -299,7 +386,7 @@ Here is one way you might customize `RestLink`:
 
 <h3 id="context.headers">Example</h3>
 
-`RestLink` uses the `headers` field on the [`apollo-link-context`](./context.html) so you can compose other links that provide additional & dynamic headers to a given query. 
+`RestLink` uses the `headers` field on the [`apollo-link-context`](./context.html) so you can compose other links that provide additional & dynamic headers to a given query.
 
 Here is one way to add request `headers` to the context and retrieve the response headers of the operation:
 
@@ -319,7 +406,7 @@ const authRestLink = new ApolloLink((operation, forward) => {
     const { restResponses } = operation.getContext();
     const authTokenResponse = restResponses.find(res => res.headers.has("Authorization"));
     // You might also filter on res.url to find the response of a specific API call
-    return authTokenResponse 
+    return authTokenResponse
       ? localStorage.setItem("token", authTokenResponse.headers.get('Authorization')).then(() => result)
       : result;
   });
@@ -384,9 +471,9 @@ query postTitle {
 }
 ```
 
-*Warning*: Variables in the main path will not automatically have `encodeURIComponent` called on them 
+*Warning*: Variables in the main path will not automatically have `encodeURIComponent` called on them
 
-Additionally, you can also control the query-string: 
+Additionally, you can also control the query-string:
 
 ```graphql
 query postTitle {
@@ -400,7 +487,7 @@ query postTitle {
 
 Things to note:
 
-1. This will be converted into `/search?query=some%20key%20words&page_size=5&lang=en` 
+1. This will be converted into `/search?query=some%20key%20words&page_size=5&lang=en`
 2. The `context.language / lang=en` is extracting an object from the Apollo Context, that was added via an `apollo-link-context` Link.
 3. The query string arguments are assembled by npm:qs and have `encodeURIComponent` called on them.
 


### PR DESCRIPTION
Docs update, synching the docs from our latest release.

Release: https://github.com/apollographql/apollo-link-rest/releases/tag/v0.7.0