### PR TITLE
Add `apollo-link-http-common` as a dependency

### DIFF
--- a/packages/apollo-link-error/package.json
+++ b/packages/apollo-link-error/package.json
@@ -32,12 +32,12 @@
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
-    "apollo-link": "^1.2.6"
+    "apollo-link": "^1.2.6",
+    "apollo-link-http-common": "^0.2.8"
   },
   "devDependencies": {
     "@types/graphql": "14.0.3",
     "@types/jest": "22.2.3",
-    "apollo-link-http-common": "^0.2.8",
     "browserify": "16.2.3",
     "graphql": "14.0.2",
     "graphql-tag": "2.10.0",


### PR DESCRIPTION
https://github.com/apollographql/apollo-link/pull/530 added `apollo-link-http-common` as a dev dependency, when it should have been added as a normal dependency (since it's referenced by the production version of `apollo-link-error`). This commit switches it to be a production dependency.

Fixes https://github.com/apollographql/apollo-link/issues/887.