### PR TITLE
Return null when headers are not parsed properly

### DIFF
--- a/packages/apollo-link-http/src/httpLink.ts
+++ b/packages/apollo-link-http/src/httpLink.ts
@@ -66,6 +66,7 @@ function parseMultipartHTTP(plaintext: string): FetchResult[] | null {
     if (part.length) {
       let partArr = part.split('\r\n\r\n');
       if (!partArr || partArr.length !== 2) {
+        return null;
       }
 
       // Read the Content-Length header, which must be included in the response


### PR DESCRIPTION
To indicate an incomplete multipart.

