### PR TITLE
chore: remove docs CI job since it is not relevant, netlify does this

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,23 +43,6 @@ jobs:
       - <<: *attach
       - run: npm run lint-check
 
-  Docs:
-    <<: *defaults
-    steps:
-      - <<: *attach
-      - restore_cache:
-          keys:
-            - npm-v2-{{ .Branch }}-{{ checksum "./docs/package-lock.json" }}
-      - run:
-          name: install-docs-npm
-          command: cd docs && npm i
-      - run: git checkout ./docs/package.json
-      - save_cache:
-          key: npm-v2-{{ .Branch }}-{{ checksum "./docs/package-lock.json" }}
-          paths:
-            - ./docs/node_modules
-      - run: cd docs && npm run build
-
   Filesize:
     <<: *defaults
     steps:
@@ -87,9 +70,6 @@ workflows:
     jobs:
       - Build
       - Danger:
-          requires:
-            - Build
-      - Docs:
           requires:
             - Build
       - Prettier Check:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## vNext
 
+### General
+
+- Remove the docs CI step. <br/>
+  [@JoviDeCroock](https://github.com/JoviDeCroock) in [#938](https://github.com/apollographql/apollo-link/pull/938)
+
 ### docs
 
 - Documentation updates.  <br/>


### PR DESCRIPTION
Linear to apollo-client remove the docs CI job since this is handled by netlify.
