### PR TITLE
Attempt to fix out-of-memory Circle CI failures.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ jobs:
     <<: *defaults
     steps:
       - <<: *attach
+      - run: npm run build
       - run: npm run filesize
 
   Monorepo:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11583,18 +11583,6 @@
         "source-map-resolve": "^0.5.0"
       }
     },
-    "rollup-plugin-terser": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-4.0.4.tgz",
-      "integrity": "sha512-wPANT5XKVJJ8RDUN0+wIr7UPd0lIXBo4UdJ59VmlPCtlFsE20AM+14pe+tk7YunCsWEiuzkDBY3QIkSCjtrPXg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "jest-worker": "^24.0.0",
-        "serialize-javascript": "^1.6.1",
-        "terser": "^3.14.1"
-      }
-    },
     "rollup-plugin-typescript2": {
       "version": "0.19.3",
       "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.19.3.tgz",
@@ -11859,12 +11847,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
-      "dev": true
-    },
-    "serialize-javascript": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.6.1.tgz",
-      "integrity": "sha512-A5MOagrPFga4YaKQSWHryl7AXvbQkEqpw4NNYMTNYUNV51bA8ABHgYFpqKx+YFFrw59xMV1qGH1R4AgoNIVgCw==",
       "dev": true
     },
     "set-blocking": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -254,6 +254,24 @@
         }
       }
     },
+    "@condenast/bundlesize": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@condenast/bundlesize/-/bundlesize-0.18.1.tgz",
+      "integrity": "sha512-i/GG6p8j9BRrts4sG7ECLN5WrcJj+ubYEM+F6dR1BwbTHKo7Lt0sx6y/sZf1pg4jbHyGOHAe3jedkiVoj6e/qw==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.17.0",
+        "brotli-size": "0.0.3",
+        "bytes": "^3.0.0",
+        "ci-env": "^1.4.0",
+        "commander": "^2.11.0",
+        "github-build": "^1.2.0",
+        "glob": "^7.1.2",
+        "gzip-size": "^4.0.0",
+        "prettycli": "^1.4.3",
+        "read-pkg-up": "^3.0.0"
+      }
+    },
     "@lerna/add": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.13.1.tgz",
@@ -2615,13 +2633,13 @@
       }
     },
     "brotli-size": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/brotli-size/-/brotli-size-0.0.1.tgz",
-      "integrity": "sha1-jBruoBzSLzWbBIlRGFvVOf8Mgp8=",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/brotli-size/-/brotli-size-0.0.3.tgz",
+      "integrity": "sha512-bBIdd8uUGxKGldAVykxOqPegl+HlIm4FpXJamwWw5x77WCE8jO7AhXFE1YXOhOB28gS+2pTQete0FqRE6U5hQQ==",
       "dev": true,
       "requires": {
         "duplexer": "^0.1.1",
-        "iltorb": "^1.0.9"
+        "iltorb": "^2.0.5"
       }
     },
     "browser-process-hrtime": {
@@ -2707,24 +2725,6 @@
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
       "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true
-    },
-    "bundlesize": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/bundlesize/-/bundlesize-0.17.1.tgz",
-      "integrity": "sha512-p5I5Tpoug9aOVGg4kQETMJ8xquY66mX9XI19kXkkAFnmDhDXwSF+1jq1OjBGz7h27TAulM3k2wLEJPvickTt0A==",
-      "dev": true,
-      "requires": {
-        "axios": "^0.17.0",
-        "brotli-size": "0.0.1",
-        "bytes": "^3.0.0",
-        "ci-env": "^1.4.0",
-        "commander": "^2.11.0",
-        "github-build": "^1.2.0",
-        "glob": "^7.1.2",
-        "gzip-size": "^4.0.0",
-        "prettycli": "^1.4.3",
-        "read-pkg-up": "^3.0.0"
-      }
     },
     "byline": {
       "version": "5.0.0",
@@ -3731,9 +3731,9 @@
       "dev": true
     },
     "detect-libc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-0.2.0.tgz",
-      "integrity": "sha1-R/31ZzSKF+wl/L8LnkRjSKdvn7U=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "dev": true
     },
     "detect-newline": {
@@ -4076,9 +4076,9 @@
       }
     },
     "expand-template": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
-      "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "dev": true
     },
     "expand-tilde": {
@@ -4319,12 +4319,29 @@
       }
     },
     "follow-redirects": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
-      "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+      "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
       "dev": true,
       "requires": {
-        "debug": "=3.1.0"
+        "debug": "^3.2.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
       }
     },
     "for-in": {
@@ -5713,15 +5730,15 @@
       }
     },
     "iltorb": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/iltorb/-/iltorb-1.3.10.tgz",
-      "integrity": "sha512-nyB4+ru1u8CQqQ6w7YjasboKN3NQTN8GH/V/eEssNRKhW6UbdxdWhB9fJ5EEdjJfezKY0qPrcwLyIcgjL8hHxA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/iltorb/-/iltorb-2.4.1.tgz",
+      "integrity": "sha512-huyAN7dSNe2b7VAl5AyvaeZ8XTcDTSF1b8JVYDggl+SBfHsORq3qMZeesZW7zoEy21s15SiERAITWT5cwxu1Uw==",
       "dev": true,
       "requires": {
-        "detect-libc": "^0.2.0",
-        "nan": "^2.6.2",
-        "node-gyp": "^3.6.2",
-        "prebuild-install": "^2.3.0"
+        "detect-libc": "^1.0.3",
+        "npmlog": "^4.1.2",
+        "prebuild-install": "^5.2.1",
+        "which-pm-runs": "^1.0.0"
       }
     },
     "import-fresh": {
@@ -9870,7 +9887,8 @@
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
       "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -9912,6 +9930,12 @@
         }
       }
     },
+    "napi-build-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.1.tgz",
+      "integrity": "sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA==",
+      "dev": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -9925,9 +9949,9 @@
       "dev": true
     },
     "node-abi": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.6.0.tgz",
-      "integrity": "sha512-kCnEh6af6Z6DB7RFI/7LHNwqRjvJW7rgrv3lhIFoQ/+XhLPI/lJYwsk5vzvkldPWWgqnAMcuPF5S8/jj56kVOA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.7.1.tgz",
+      "integrity": "sha512-OV8Bq1OrPh6z+Y4dqwo05HqrRL9YNF7QVMRfq1/pguwKLG+q9UB/Lk0x5qXjO23JjJg+/jqCHSTaG1P3tfKfuw==",
       "dev": true,
       "requires": {
         "semver": "^5.4.1"
@@ -10891,34 +10915,29 @@
       }
     },
     "prebuild-install": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
-      "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.2.4.tgz",
+      "integrity": "sha512-CG3JnpTZXdmr92GW4zbcba4jkDha6uHraJ7hW4Fn8j0mExxwOKK20hqho8ZuBDCKYCHYIkFM1P2jhtG+KpP4fg==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3",
-        "expand-template": "^1.0.2",
+        "expand-template": "^2.0.3",
         "github-from-package": "0.0.0",
         "minimist": "^1.2.0",
         "mkdirp": "^0.5.1",
-        "node-abi": "^2.2.0",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.7.0",
         "noop-logger": "^0.1.1",
         "npmlog": "^4.0.1",
         "os-homedir": "^1.0.1",
         "pump": "^2.0.1",
-        "rc": "^1.1.6",
+        "rc": "^1.2.7",
         "simple-get": "^2.7.0",
         "tar-fs": "^1.13.0",
         "tunnel-agent": "^0.6.0",
         "which-pm-runs": "^1.0.0"
       },
       "dependencies": {
-        "detect-libc": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-          "dev": true
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,8 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "bootstrap": "lerna exec -- npm install && lerna run prepare && lerna link",
     "diff": "check-if-folder-contents-changed-in-git-commit-range",
-    "postinstall": "npm run bootstrap",
-    "postbootstrap": "npm run build",
+    "postinstall": "lerna exec -- npm install",
     "build": "lerna run build",
     "test": "lerna run test",
     "prelint": "npm run lint-fix",
@@ -18,7 +16,7 @@
     "coverage": "jest --verbose --coverage",
     "coverage:upload": "codecov",
     "danger": "danger run --verbose",
-    "predeploy": "npm run bootstrap",
+    "predeploy": "npm install",
     "test-ci": "npm run coverage -- --ci --maxWorkers=2 --reporters=default --reporters=jest-junit",
     "deploy": "lerna publish -m \"chore: Publish\"",
     "watch": "trap \"kill 0\" SIGINT; for f in `ls packages`; do (cd `pwd`/packages/$f && [[ -e package.json ]] && npm run watch) & done; "

--- a/package.json
+++ b/package.json
@@ -99,8 +99,8 @@
   "pre-push": "lint-check",
   "dependencies": {},
   "devDependencies": {
+    "@condenast/bundlesize": "^0.18.1",
     "@types/zen-observable": "0.8.0",
-    "bundlesize": "0.17.1",
     "check-if-folder-contents-changed-in-git-commit-range": "1.0.0",
     "codecov": "3.2.0",
     "danger": "3.9.0",

--- a/package.json
+++ b/package.json
@@ -115,8 +115,8 @@
     "rollup": "1.2.3",
     "rollup-plugin-node-resolve": "4.0.1",
     "rollup-plugin-sourcemaps": "0.4.2",
-    "rollup-plugin-terser": "^4.0.4",
     "rollup-plugin-typescript2": "0.19.3",
+    "terser": "^3.16.1",
     "ts-jest": "22.4.6",
     "tslib": "1.9.3",
     "typescript": "3.0.3"

--- a/packages/apollo-link-batch-http/package-lock.json
+++ b/packages/apollo-link-batch-http/package-lock.json
@@ -51,9 +51,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.12.18",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-			"integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+			"version": "11.10.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.4.tgz",
+			"integrity": "sha512-wa09itaLE8L705aXd8F80jnFpxz3Y1/KRHfKsYL2bPc0XF+wEWu8sR9n5bmeu8Ba1N9z2GRNzm/YdHcghLkLKg==",
 			"dev": true
 		},
 		"abab": {
@@ -4890,13 +4890,22 @@
 			}
 		},
 		"rollup": {
-			"version": "0.68.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.68.2.tgz",
-			"integrity": "sha512-WgjNCXYv7ZbtStIap1+tz4pd2zwz0XYN//OILwEY6dINIFLVizK1iWdu+ZtUURL/OKnp8Lv2w8FBds8YihzX7Q==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-1.4.1.tgz",
+			"integrity": "sha512-YWf5zeR6SWtqZmCnuYs4a+ZJetj8NT4yfBMPXekWHW4L3144jM+J2AWagQVejB0FwCqjEUP9l8o4hg1rPDfQlg==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "0.0.39",
-				"@types/node": "*"
+				"@types/node": "^11.9.5",
+				"acorn": "^6.1.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"dev": true
+				}
 			}
 		},
 		"rsvp": {

--- a/packages/apollo-link-batch-http/package-lock.json
+++ b/packages/apollo-link-batch-http/package-lock.json
@@ -403,6 +403,27 @@
 				}
 			}
 		},
+		"apollo-link": {
+			"version": "file:../apollo-link",
+			"requires": {
+				"tslib": "^1.9.3",
+				"zen-observable-ts": "file:../zen-observable-ts"
+			}
+		},
+		"apollo-link-batch": {
+			"version": "file:../apollo-link-batch",
+			"requires": {
+				"apollo-link": "file:../apollo-link",
+				"tslib": "^1.9.3"
+			}
+		},
+		"apollo-link-http-common": {
+			"version": "file:../apollo-link-http-common",
+			"requires": {
+				"apollo-link": "file:../apollo-link",
+				"tslib": "^1.9.3"
+			}
+		},
 		"append-transform": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
@@ -5842,6 +5863,7 @@
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
 			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"commander": "~2.17.1",
 				"source-map": "~0.6.1"
@@ -5851,7 +5873,8 @@
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/packages/apollo-link-batch-http/package.json
+++ b/packages/apollo-link-batch-http/package.json
@@ -28,7 +28,7 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepublishOnly": "npm run clean && npm run build",
+    "prepare": "npm run build",
     "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },

--- a/packages/apollo-link-batch-http/package.json
+++ b/packages/apollo-link-batch-http/package.json
@@ -51,7 +51,7 @@
     "object-to-querystring": "1.0.8",
     "proxyquire": "1.8.0",
     "rimraf": "2.6.3",
-    "rollup": "^1.4.1",
+    "rollup": "1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3"

--- a/packages/apollo-link-batch-http/package.json
+++ b/packages/apollo-link-batch-http/package.json
@@ -51,7 +51,7 @@
     "object-to-querystring": "1.0.8",
     "proxyquire": "1.8.0",
     "rimraf": "2.6.3",
-    "rollup": "0.68.2",
+    "rollup": "^1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3"

--- a/packages/apollo-link-batch-http/package.json
+++ b/packages/apollo-link-batch-http/package.json
@@ -25,7 +25,7 @@
     "build": "tsc && rollup -c",
     "coverage": "jest --coverage",
     "clean": "rimraf lib/* && rimraf coverage/*",
-    "filesize": "npm run build",
+    "filesize": "../../scripts/minify",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
     "prepare": "npm run build",

--- a/packages/apollo-link-batch-http/package.json
+++ b/packages/apollo-link-batch-http/package.json
@@ -28,9 +28,8 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepare": "npm run lint && npm run build",
     "prepublishOnly": "npm run clean && npm run build",
-    "test": "jest",
+    "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {

--- a/packages/apollo-link-batch-http/package.json
+++ b/packages/apollo-link-batch-http/package.json
@@ -34,9 +34,9 @@
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
-    "apollo-link": "^1.2.8",
-    "apollo-link-batch": "^1.1.9",
-    "apollo-link-http-common": "^0.2.10",
+    "apollo-link": "file:../apollo-link",
+    "apollo-link-batch": "file:../apollo-link-batch",
+    "apollo-link-http-common": "file:../apollo-link-http-common",
     "tslib": "^1.9.3"
   },
   "peerDependencies": {

--- a/packages/apollo-link-batch/package-lock.json
+++ b/packages/apollo-link-batch/package-lock.json
@@ -51,9 +51,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.12.18",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-			"integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+			"version": "11.10.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.4.tgz",
+			"integrity": "sha512-wa09itaLE8L705aXd8F80jnFpxz3Y1/KRHfKsYL2bPc0XF+wEWu8sR9n5bmeu8Ba1N9z2GRNzm/YdHcghLkLKg==",
 			"dev": true
 		},
 		"abab": {
@@ -4870,13 +4870,22 @@
 			}
 		},
 		"rollup": {
-			"version": "0.68.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.68.2.tgz",
-			"integrity": "sha512-WgjNCXYv7ZbtStIap1+tz4pd2zwz0XYN//OILwEY6dINIFLVizK1iWdu+ZtUURL/OKnp8Lv2w8FBds8YihzX7Q==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-1.4.1.tgz",
+			"integrity": "sha512-YWf5zeR6SWtqZmCnuYs4a+ZJetj8NT4yfBMPXekWHW4L3144jM+J2AWagQVejB0FwCqjEUP9l8o4hg1rPDfQlg==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "0.0.39",
-				"@types/node": "*"
+				"@types/node": "^11.9.5",
+				"acorn": "^6.1.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"dev": true
+				}
 			}
 		},
 		"rsvp": {

--- a/packages/apollo-link-batch/package-lock.json
+++ b/packages/apollo-link-batch/package-lock.json
@@ -403,6 +403,13 @@
 				}
 			}
 		},
+		"apollo-link": {
+			"version": "file:../apollo-link",
+			"requires": {
+				"tslib": "^1.9.3",
+				"zen-observable-ts": "file:../zen-observable-ts"
+			}
+		},
 		"append-transform": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
@@ -5836,6 +5843,7 @@
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
 			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"commander": "~2.17.1",
 				"source-map": "~0.6.1"
@@ -5845,7 +5853,8 @@
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/packages/apollo-link-batch/package.json
+++ b/packages/apollo-link-batch/package.json
@@ -45,7 +45,7 @@
     "jest": "22.4.4",
     "proxyquire": "1.8.0",
     "rimraf": "2.6.3",
-    "rollup": "^1.4.1",
+    "rollup": "1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3"

--- a/packages/apollo-link-batch/package.json
+++ b/packages/apollo-link-batch/package.json
@@ -28,7 +28,7 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepublishOnly": "npm run clean && npm run build",
+    "prepare": "npm run build",
     "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },

--- a/packages/apollo-link-batch/package.json
+++ b/packages/apollo-link-batch/package.json
@@ -45,7 +45,7 @@
     "jest": "22.4.4",
     "proxyquire": "1.8.0",
     "rimraf": "2.6.3",
-    "rollup": "0.68.2",
+    "rollup": "^1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3"

--- a/packages/apollo-link-batch/package.json
+++ b/packages/apollo-link-batch/package.json
@@ -25,7 +25,7 @@
     "build": "tsc && rollup -c",
     "coverage": "jest --coverage",
     "clean": "rimraf lib/* && rimraf coverage/*",
-    "filesize": "npm run build",
+    "filesize": "../../scripts/minify",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
     "prepare": "npm run build",

--- a/packages/apollo-link-batch/package.json
+++ b/packages/apollo-link-batch/package.json
@@ -34,7 +34,7 @@
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
-    "apollo-link": "^1.2.8",
+    "apollo-link": "file:../apollo-link",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/apollo-link-batch/package.json
+++ b/packages/apollo-link-batch/package.json
@@ -28,9 +28,8 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepare": "npm run lint && npm run build",
     "prepublishOnly": "npm run clean && npm run build",
-    "test": "jest",
+    "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {

--- a/packages/apollo-link-context/package-lock.json
+++ b/packages/apollo-link-context/package-lock.json
@@ -51,9 +51,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.12.18",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-			"integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+			"version": "11.10.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.4.tgz",
+			"integrity": "sha512-wa09itaLE8L705aXd8F80jnFpxz3Y1/KRHfKsYL2bPc0XF+wEWu8sR9n5bmeu8Ba1N9z2GRNzm/YdHcghLkLKg==",
 			"dev": true
 		},
 		"abab": {
@@ -4781,13 +4781,22 @@
 			}
 		},
 		"rollup": {
-			"version": "0.68.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.68.2.tgz",
-			"integrity": "sha512-WgjNCXYv7ZbtStIap1+tz4pd2zwz0XYN//OILwEY6dINIFLVizK1iWdu+ZtUURL/OKnp8Lv2w8FBds8YihzX7Q==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-1.4.1.tgz",
+			"integrity": "sha512-YWf5zeR6SWtqZmCnuYs4a+ZJetj8NT4yfBMPXekWHW4L3144jM+J2AWagQVejB0FwCqjEUP9l8o4hg1rPDfQlg==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "0.0.39",
-				"@types/node": "*"
+				"@types/node": "^11.9.5",
+				"acorn": "^6.1.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"dev": true
+				}
 			}
 		},
 		"rsvp": {

--- a/packages/apollo-link-context/package-lock.json
+++ b/packages/apollo-link-context/package-lock.json
@@ -403,6 +403,13 @@
 				}
 			}
 		},
+		"apollo-link": {
+			"version": "file:../apollo-link",
+			"requires": {
+				"tslib": "^1.9.3",
+				"zen-observable-ts": "file:../zen-observable-ts"
+			}
+		},
 		"append-transform": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
@@ -5747,6 +5754,7 @@
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
 			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"commander": "~2.17.1",
 				"source-map": "~0.6.1"
@@ -5756,7 +5764,8 @@
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/packages/apollo-link-context/package.json
+++ b/packages/apollo-link-context/package.json
@@ -19,7 +19,7 @@
     "build": "tsc && rollup -c",
     "clean": "rimraf lib/* && rimraf coverage/*",
     "coverage": "jest --coverage",
-    "filesize": "npm run build",
+    "filesize": "../../scripts/minify",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
     "prepare": "npm run build",

--- a/packages/apollo-link-context/package.json
+++ b/packages/apollo-link-context/package.json
@@ -37,7 +37,7 @@
     "graphql-tag": "2.10.1",
     "jest": "22.4.4",
     "rimraf": "2.6.3",
-    "rollup": "0.68.2",
+    "rollup": "^1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3"

--- a/packages/apollo-link-context/package.json
+++ b/packages/apollo-link-context/package.json
@@ -22,7 +22,7 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepublishOnly": "npm run clean && npm run build",
+    "prepare": "npm run build",
     "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },

--- a/packages/apollo-link-context/package.json
+++ b/packages/apollo-link-context/package.json
@@ -37,7 +37,7 @@
     "graphql-tag": "2.10.1",
     "jest": "22.4.4",
     "rimraf": "2.6.3",
-    "rollup": "^1.4.1",
+    "rollup": "1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3"

--- a/packages/apollo-link-context/package.json
+++ b/packages/apollo-link-context/package.json
@@ -22,9 +22,8 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepare": "npm run lint && npm run build",
     "prepublishOnly": "npm run clean && npm run build",
-    "test": "jest",
+    "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {

--- a/packages/apollo-link-context/package.json
+++ b/packages/apollo-link-context/package.json
@@ -28,7 +28,7 @@
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
-    "apollo-link": "^1.2.8",
+    "apollo-link": "file:../apollo-link",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/apollo-link-dedup/package-lock.json
+++ b/packages/apollo-link-dedup/package-lock.json
@@ -403,6 +403,13 @@
         }
       }
     },
+    "apollo-link": {
+      "version": "file:../apollo-link",
+      "requires": {
+        "tslib": "^1.9.3",
+        "zen-observable-ts": "file:../zen-observable-ts"
+      }
+    },
     "append-transform": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
@@ -5813,6 +5820,7 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
       "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
       "dev": true,
+      "optional": true,
       "requires": {
         "commander": "~2.17.1",
         "source-map": "~0.6.1"
@@ -5822,7 +5830,8 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/packages/apollo-link-dedup/package-lock.json
+++ b/packages/apollo-link-dedup/package-lock.json
@@ -51,9 +51,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.12.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+      "version": "11.10.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.4.tgz",
+      "integrity": "sha512-wa09itaLE8L705aXd8F80jnFpxz3Y1/KRHfKsYL2bPc0XF+wEWu8sR9n5bmeu8Ba1N9z2GRNzm/YdHcghLkLKg==",
       "dev": true
     },
     "abab": {
@@ -4847,13 +4847,22 @@
       }
     },
     "rollup": {
-      "version": "0.68.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.68.2.tgz",
-      "integrity": "sha512-WgjNCXYv7ZbtStIap1+tz4pd2zwz0XYN//OILwEY6dINIFLVizK1iWdu+ZtUURL/OKnp8Lv2w8FBds8YihzX7Q==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.4.1.tgz",
+      "integrity": "sha512-YWf5zeR6SWtqZmCnuYs4a+ZJetj8NT4yfBMPXekWHW4L3144jM+J2AWagQVejB0FwCqjEUP9l8o4hg1rPDfQlg==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
-        "@types/node": "*"
+        "@types/node": "^11.9.5",
+        "acorn": "^6.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+          "dev": true
+        }
       }
     },
     "rsvp": {

--- a/packages/apollo-link-dedup/package.json
+++ b/packages/apollo-link-dedup/package.json
@@ -43,7 +43,7 @@
     "graphql-tag": "2.10.1",
     "jest": "22.4.4",
     "rimraf": "2.6.3",
-    "rollup": "^1.4.1",
+    "rollup": "1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3"

--- a/packages/apollo-link-dedup/package.json
+++ b/packages/apollo-link-dedup/package.json
@@ -28,7 +28,7 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepublishOnly": "npm run clean && npm run build",
+    "prepare": "npm run build",
     "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },

--- a/packages/apollo-link-dedup/package.json
+++ b/packages/apollo-link-dedup/package.json
@@ -25,7 +25,7 @@
     "build": "tsc && rollup -c",
     "clean": "rimraf lib/* && rimraf coverage/*",
     "coverage": "jest --coverage",
-    "filesize": "npm run build",
+    "filesize": "../../scripts/minify",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
     "prepare": "npm run build",

--- a/packages/apollo-link-dedup/package.json
+++ b/packages/apollo-link-dedup/package.json
@@ -43,7 +43,7 @@
     "graphql-tag": "2.10.1",
     "jest": "22.4.4",
     "rimraf": "2.6.3",
-    "rollup": "0.68.2",
+    "rollup": "^1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3"

--- a/packages/apollo-link-dedup/package.json
+++ b/packages/apollo-link-dedup/package.json
@@ -34,7 +34,7 @@
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
-    "apollo-link": "^1.2.8",
+    "apollo-link": "file:../apollo-link",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/apollo-link-dedup/package.json
+++ b/packages/apollo-link-dedup/package.json
@@ -28,9 +28,8 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepare": "npm run lint && npm run build",
     "prepublishOnly": "npm run clean && npm run build",
-    "test": "jest",
+    "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {

--- a/packages/apollo-link-error/package-lock.json
+++ b/packages/apollo-link-error/package-lock.json
@@ -403,6 +403,20 @@
 				}
 			}
 		},
+		"apollo-link": {
+			"version": "file:../apollo-link",
+			"requires": {
+				"tslib": "^1.9.3",
+				"zen-observable-ts": "file:../zen-observable-ts"
+			}
+		},
+		"apollo-link-http-common": {
+			"version": "file:../apollo-link-http-common",
+			"requires": {
+				"apollo-link": "file:../apollo-link",
+				"tslib": "^1.9.3"
+			}
+		},
 		"append-transform": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
@@ -5747,6 +5761,7 @@
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
 			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"commander": "~2.17.1",
 				"source-map": "~0.6.1"
@@ -5756,7 +5771,8 @@
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/packages/apollo-link-error/package-lock.json
+++ b/packages/apollo-link-error/package-lock.json
@@ -51,9 +51,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.12.18",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-			"integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+			"version": "11.10.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.4.tgz",
+			"integrity": "sha512-wa09itaLE8L705aXd8F80jnFpxz3Y1/KRHfKsYL2bPc0XF+wEWu8sR9n5bmeu8Ba1N9z2GRNzm/YdHcghLkLKg==",
 			"dev": true
 		},
 		"abab": {
@@ -4788,13 +4788,22 @@
 			}
 		},
 		"rollup": {
-			"version": "0.68.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.68.2.tgz",
-			"integrity": "sha512-WgjNCXYv7ZbtStIap1+tz4pd2zwz0XYN//OILwEY6dINIFLVizK1iWdu+ZtUURL/OKnp8Lv2w8FBds8YihzX7Q==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-1.4.1.tgz",
+			"integrity": "sha512-YWf5zeR6SWtqZmCnuYs4a+ZJetj8NT4yfBMPXekWHW4L3144jM+J2AWagQVejB0FwCqjEUP9l8o4hg1rPDfQlg==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "0.0.39",
-				"@types/node": "*"
+				"@types/node": "^11.9.5",
+				"acorn": "^6.1.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"dev": true
+				}
 			}
 		},
 		"rsvp": {

--- a/packages/apollo-link-error/package.json
+++ b/packages/apollo-link-error/package.json
@@ -19,7 +19,7 @@
     "build": "tsc && rollup -c",
     "clean": "rimraf lib/* && rimraf coverage/*",
     "coverage": "jest --coverage",
-    "filesize": "npm run build",
+    "filesize": "../../scripts/minify",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
     "prepare": "npm run build",

--- a/packages/apollo-link-error/package.json
+++ b/packages/apollo-link-error/package.json
@@ -38,7 +38,7 @@
     "graphql-tag": "2.10.1",
     "jest": "22.4.4",
     "rimraf": "2.6.3",
-    "rollup": "^1.4.1",
+    "rollup": "1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3"

--- a/packages/apollo-link-error/package.json
+++ b/packages/apollo-link-error/package.json
@@ -22,7 +22,7 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepublishOnly": "npm run clean && npm run build",
+    "prepare": "npm run build",
     "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },

--- a/packages/apollo-link-error/package.json
+++ b/packages/apollo-link-error/package.json
@@ -38,7 +38,7 @@
     "graphql-tag": "2.10.1",
     "jest": "22.4.4",
     "rimraf": "2.6.3",
-    "rollup": "0.68.2",
+    "rollup": "^1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3"

--- a/packages/apollo-link-error/package.json
+++ b/packages/apollo-link-error/package.json
@@ -22,9 +22,8 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepare": "npm run lint && npm run build",
     "prepublishOnly": "npm run clean && npm run build",
-    "test": "jest",
+    "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {

--- a/packages/apollo-link-error/package.json
+++ b/packages/apollo-link-error/package.json
@@ -28,8 +28,8 @@
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
-    "apollo-link": "^1.2.8",
-    "apollo-link-http-common": "^0.2.10",
+    "apollo-link": "file:../apollo-link",
+    "apollo-link-http-common": "file:../apollo-link-http-common",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/apollo-link-http-common/package-lock.json
+++ b/packages/apollo-link-http-common/package-lock.json
@@ -403,6 +403,13 @@
 				}
 			}
 		},
+		"apollo-link": {
+			"version": "file:../apollo-link",
+			"requires": {
+				"tslib": "^1.9.3",
+				"zen-observable-ts": "file:../zen-observable-ts"
+			}
+		},
 		"append-transform": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
@@ -5795,6 +5802,7 @@
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
 			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"commander": "~2.17.1",
 				"source-map": "~0.6.1"
@@ -5804,7 +5812,8 @@
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/packages/apollo-link-http-common/package-lock.json
+++ b/packages/apollo-link-http-common/package-lock.json
@@ -51,9 +51,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.12.18",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-			"integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+			"version": "11.10.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.4.tgz",
+			"integrity": "sha512-wa09itaLE8L705aXd8F80jnFpxz3Y1/KRHfKsYL2bPc0XF+wEWu8sR9n5bmeu8Ba1N9z2GRNzm/YdHcghLkLKg==",
 			"dev": true
 		},
 		"abab": {
@@ -4829,13 +4829,22 @@
 			}
 		},
 		"rollup": {
-			"version": "0.68.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.68.2.tgz",
-			"integrity": "sha512-WgjNCXYv7ZbtStIap1+tz4pd2zwz0XYN//OILwEY6dINIFLVizK1iWdu+ZtUURL/OKnp8Lv2w8FBds8YihzX7Q==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-1.4.1.tgz",
+			"integrity": "sha512-YWf5zeR6SWtqZmCnuYs4a+ZJetj8NT4yfBMPXekWHW4L3144jM+J2AWagQVejB0FwCqjEUP9l8o4hg1rPDfQlg==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "0.0.39",
-				"@types/node": "*"
+				"@types/node": "^11.9.5",
+				"acorn": "^6.1.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"dev": true
+				}
 			}
 		},
 		"rsvp": {

--- a/packages/apollo-link-http-common/package.json
+++ b/packages/apollo-link-http-common/package.json
@@ -12,7 +12,7 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepublishOnly": "npm run clean && npm run build",
+    "prepare": "npm run build",
     "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },

--- a/packages/apollo-link-http-common/package.json
+++ b/packages/apollo-link-http-common/package.json
@@ -12,9 +12,8 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepare": "npm run lint && npm run build",
     "prepublishOnly": "npm run clean && npm run build",
-    "test": "jest",
+    "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "keywords": [

--- a/packages/apollo-link-http-common/package.json
+++ b/packages/apollo-link-http-common/package.json
@@ -39,7 +39,7 @@
     "jest": "22.4.4",
     "object-to-querystring": "1.0.8",
     "rimraf": "2.6.3",
-    "rollup": "0.68.2",
+    "rollup": "^1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3"

--- a/packages/apollo-link-http-common/package.json
+++ b/packages/apollo-link-http-common/package.json
@@ -9,7 +9,7 @@
     "build": "tsc && rollup -c",
     "clean": "rimraf lib/* && rimraf coverage/*",
     "coverage": "jest --coverage",
-    "filesize": "npm run build",
+    "filesize": "../../scripts/minify",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
     "prepare": "npm run build",

--- a/packages/apollo-link-http-common/package.json
+++ b/packages/apollo-link-http-common/package.json
@@ -25,7 +25,7 @@
   "author": "Evans Hauser",
   "license": "MIT",
   "dependencies": {
-    "apollo-link": "^1.2.8",
+    "apollo-link": "file:../apollo-link",
     "tslib": "^1.9.3"
   },
   "peerDependencies": {

--- a/packages/apollo-link-http-common/package.json
+++ b/packages/apollo-link-http-common/package.json
@@ -39,7 +39,7 @@
     "jest": "22.4.4",
     "object-to-querystring": "1.0.8",
     "rimraf": "2.6.3",
-    "rollup": "^1.4.1",
+    "rollup": "1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3"

--- a/packages/apollo-link-http/package-lock.json
+++ b/packages/apollo-link-http/package-lock.json
@@ -412,6 +412,20 @@
 				"cross-fetch": "^1.0.0"
 			}
 		},
+		"apollo-link": {
+			"version": "file:../apollo-link",
+			"requires": {
+				"tslib": "^1.9.3",
+				"zen-observable-ts": "file:../zen-observable-ts"
+			}
+		},
+		"apollo-link-http-common": {
+			"version": "file:../apollo-link-http-common",
+			"requires": {
+				"apollo-link": "file:../apollo-link",
+				"tslib": "^1.9.3"
+			}
+		},
 		"append-transform": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
@@ -5833,6 +5847,7 @@
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
 			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"commander": "~2.17.1",
 				"source-map": "~0.6.1"
@@ -5842,7 +5857,8 @@
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/packages/apollo-link-http/package-lock.json
+++ b/packages/apollo-link-http/package-lock.json
@@ -51,9 +51,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.12.18",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-			"integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+			"version": "11.10.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.4.tgz",
+			"integrity": "sha512-wa09itaLE8L705aXd8F80jnFpxz3Y1/KRHfKsYL2bPc0XF+wEWu8sR9n5bmeu8Ba1N9z2GRNzm/YdHcghLkLKg==",
 			"dev": true
 		},
 		"abab": {
@@ -4874,13 +4874,22 @@
 			}
 		},
 		"rollup": {
-			"version": "0.68.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.68.2.tgz",
-			"integrity": "sha512-WgjNCXYv7ZbtStIap1+tz4pd2zwz0XYN//OILwEY6dINIFLVizK1iWdu+ZtUURL/OKnp8Lv2w8FBds8YihzX7Q==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-1.4.1.tgz",
+			"integrity": "sha512-YWf5zeR6SWtqZmCnuYs4a+ZJetj8NT4yfBMPXekWHW4L3144jM+J2AWagQVejB0FwCqjEUP9l8o4hg1rPDfQlg==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "0.0.39",
-				"@types/node": "*"
+				"@types/node": "^11.9.5",
+				"acorn": "^6.1.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"dev": true
+				}
 			}
 		},
 		"rsvp": {

--- a/packages/apollo-link-http/package.json
+++ b/packages/apollo-link-http/package.json
@@ -35,8 +35,8 @@
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
-    "apollo-link": "^1.2.8",
-    "apollo-link-http-common": "^0.2.10",
+    "apollo-link": "file:../apollo-link",
+    "apollo-link-http-common": "file:../apollo-link-http-common",
     "tslib": "^1.9.3"
   },
   "peerDependencies": {

--- a/packages/apollo-link-http/package.json
+++ b/packages/apollo-link-http/package.json
@@ -26,7 +26,7 @@
     "build": "tsc && rollup -c",
     "clean": "rimraf lib/* && rimraf coverage/*",
     "coverage": "jest --coverage",
-    "filesize": "npm run build",
+    "filesize": "../../scripts/minify",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
     "prepare": "npm run build",

--- a/packages/apollo-link-http/package.json
+++ b/packages/apollo-link-http/package.json
@@ -29,9 +29,8 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepare": "npm run lint && npm run build",
     "prepublishOnly": "npm run clean && npm run build",
-    "test": "jest",
+    "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {

--- a/packages/apollo-link-http/package.json
+++ b/packages/apollo-link-http/package.json
@@ -51,7 +51,7 @@
     "jest": "22.4.4",
     "object-to-querystring": "1.0.8",
     "rimraf": "2.6.3",
-    "rollup": "0.68.2",
+    "rollup": "^1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3"

--- a/packages/apollo-link-http/package.json
+++ b/packages/apollo-link-http/package.json
@@ -29,7 +29,7 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepublishOnly": "npm run clean && npm run build",
+    "prepare": "npm run build",
     "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },

--- a/packages/apollo-link-http/package.json
+++ b/packages/apollo-link-http/package.json
@@ -51,7 +51,7 @@
     "jest": "22.4.4",
     "object-to-querystring": "1.0.8",
     "rimraf": "2.6.3",
-    "rollup": "^1.4.1",
+    "rollup": "1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3"

--- a/packages/apollo-link-polling/package-lock.json
+++ b/packages/apollo-link-polling/package-lock.json
@@ -51,9 +51,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.12.18",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-			"integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+			"version": "11.10.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.4.tgz",
+			"integrity": "sha512-wa09itaLE8L705aXd8F80jnFpxz3Y1/KRHfKsYL2bPc0XF+wEWu8sR9n5bmeu8Ba1N9z2GRNzm/YdHcghLkLKg==",
 			"dev": true
 		},
 		"@types/zen-observable": {
@@ -4786,13 +4786,22 @@
 			}
 		},
 		"rollup": {
-			"version": "0.68.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.68.2.tgz",
-			"integrity": "sha512-WgjNCXYv7ZbtStIap1+tz4pd2zwz0XYN//OILwEY6dINIFLVizK1iWdu+ZtUURL/OKnp8Lv2w8FBds8YihzX7Q==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-1.4.1.tgz",
+			"integrity": "sha512-YWf5zeR6SWtqZmCnuYs4a+ZJetj8NT4yfBMPXekWHW4L3144jM+J2AWagQVejB0FwCqjEUP9l8o4hg1rPDfQlg==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "0.0.39",
-				"@types/node": "*"
+				"@types/node": "^11.9.5",
+				"acorn": "^6.1.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"dev": true
+				}
 			}
 		},
 		"rsvp": {

--- a/packages/apollo-link-polling/package-lock.json
+++ b/packages/apollo-link-polling/package-lock.json
@@ -408,6 +408,13 @@
 				}
 			}
 		},
+		"apollo-link": {
+			"version": "file:../apollo-link",
+			"requires": {
+				"tslib": "^1.9.3",
+				"zen-observable-ts": "file:../zen-observable-ts"
+			}
+		},
 		"append-transform": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
@@ -5752,6 +5759,7 @@
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
 			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"commander": "~2.17.1",
 				"source-map": "~0.6.1"
@@ -5761,7 +5769,8 @@
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/packages/apollo-link-polling/package.json
+++ b/packages/apollo-link-polling/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@types/zen-observable": "0.8.0",
-    "apollo-link": "^1.2.8",
+    "apollo-link": "file:../apollo-link",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/apollo-link-polling/package.json
+++ b/packages/apollo-link-polling/package.json
@@ -45,7 +45,7 @@
     "graphql-tag": "2.10.1",
     "jest": "22.4.4",
     "rimraf": "2.6.3",
-    "rollup": "0.68.2",
+    "rollup": "^1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3"

--- a/packages/apollo-link-polling/package.json
+++ b/packages/apollo-link-polling/package.json
@@ -26,7 +26,7 @@
     "build": "tsc && rollup -c",
     "clean": "rimraf lib/* && rimraf coverage/*",
     "coverage": "jest --coverage",
-    "filesize": "npm run build",
+    "filesize": "../../scripts/minify",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
     "prepare": "npm run build",

--- a/packages/apollo-link-polling/package.json
+++ b/packages/apollo-link-polling/package.json
@@ -29,9 +29,8 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepare": "npm run lint && npm run build",
     "prepublishOnly": "npm run clean && npm run build",
-    "test": "jest",
+    "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {

--- a/packages/apollo-link-polling/package.json
+++ b/packages/apollo-link-polling/package.json
@@ -45,7 +45,7 @@
     "graphql-tag": "2.10.1",
     "jest": "22.4.4",
     "rimraf": "2.6.3",
-    "rollup": "^1.4.1",
+    "rollup": "1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3"

--- a/packages/apollo-link-polling/package.json
+++ b/packages/apollo-link-polling/package.json
@@ -29,7 +29,7 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepublishOnly": "npm run clean && npm run build",
+    "prepare": "npm run build",
     "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },

--- a/packages/apollo-link-retry/package-lock.json
+++ b/packages/apollo-link-retry/package-lock.json
@@ -51,9 +51,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.12.18",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-			"integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+			"version": "11.10.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.4.tgz",
+			"integrity": "sha512-wa09itaLE8L705aXd8F80jnFpxz3Y1/KRHfKsYL2bPc0XF+wEWu8sR9n5bmeu8Ba1N9z2GRNzm/YdHcghLkLKg==",
 			"dev": true
 		},
 		"@types/zen-observable": {
@@ -4786,13 +4786,22 @@
 			}
 		},
 		"rollup": {
-			"version": "0.68.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.68.2.tgz",
-			"integrity": "sha512-WgjNCXYv7ZbtStIap1+tz4pd2zwz0XYN//OILwEY6dINIFLVizK1iWdu+ZtUURL/OKnp8Lv2w8FBds8YihzX7Q==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-1.4.1.tgz",
+			"integrity": "sha512-YWf5zeR6SWtqZmCnuYs4a+ZJetj8NT4yfBMPXekWHW4L3144jM+J2AWagQVejB0FwCqjEUP9l8o4hg1rPDfQlg==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "0.0.39",
-				"@types/node": "*"
+				"@types/node": "^11.9.5",
+				"acorn": "^6.1.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"dev": true
+				}
 			}
 		},
 		"rsvp": {

--- a/packages/apollo-link-retry/package-lock.json
+++ b/packages/apollo-link-retry/package-lock.json
@@ -408,6 +408,13 @@
 				}
 			}
 		},
+		"apollo-link": {
+			"version": "file:../apollo-link",
+			"requires": {
+				"tslib": "^1.9.3",
+				"zen-observable-ts": "file:../zen-observable-ts"
+			}
+		},
 		"append-transform": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
@@ -5752,6 +5759,7 @@
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
 			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"commander": "~2.17.1",
 				"source-map": "~0.6.1"
@@ -5761,7 +5769,8 @@
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/packages/apollo-link-retry/package.json
+++ b/packages/apollo-link-retry/package.json
@@ -28,7 +28,7 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepublishOnly": "npm run clean && npm run build",
+    "prepare": "npm run build",
     "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },

--- a/packages/apollo-link-retry/package.json
+++ b/packages/apollo-link-retry/package.json
@@ -25,7 +25,7 @@
     "build": "tsc && rollup -c",
     "clean": "rimraf lib/* && rimraf coverage/*",
     "coverage": "jest --coverage",
-    "filesize": "npm run build",
+    "filesize": "../../scripts/minify",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
     "prepare": "npm run build",

--- a/packages/apollo-link-retry/package.json
+++ b/packages/apollo-link-retry/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@types/zen-observable": "0.8.0",
-    "apollo-link": "^1.2.8",
+    "apollo-link": "file:../apollo-link",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/apollo-link-retry/package.json
+++ b/packages/apollo-link-retry/package.json
@@ -44,7 +44,7 @@
     "graphql-tag": "2.10.1",
     "jest": "22.4.4",
     "rimraf": "2.6.3",
-    "rollup": "^1.4.1",
+    "rollup": "1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3",

--- a/packages/apollo-link-retry/package.json
+++ b/packages/apollo-link-retry/package.json
@@ -28,9 +28,8 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepare": "npm run lint && npm run build",
     "prepublishOnly": "npm run clean && npm run build",
-    "test": "jest",
+    "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {

--- a/packages/apollo-link-retry/package.json
+++ b/packages/apollo-link-retry/package.json
@@ -44,7 +44,7 @@
     "graphql-tag": "2.10.1",
     "jest": "22.4.4",
     "rimraf": "2.6.3",
-    "rollup": "0.68.2",
+    "rollup": "^1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3",

--- a/packages/apollo-link-schema/package-lock.json
+++ b/packages/apollo-link-schema/package-lock.json
@@ -51,9 +51,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.12.18",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-			"integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+			"version": "11.10.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.4.tgz",
+			"integrity": "sha512-wa09itaLE8L705aXd8F80jnFpxz3Y1/KRHfKsYL2bPc0XF+wEWu8sR9n5bmeu8Ba1N9z2GRNzm/YdHcghLkLKg==",
 			"dev": true
 		},
 		"abab": {
@@ -4821,13 +4821,22 @@
 			}
 		},
 		"rollup": {
-			"version": "0.68.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.68.2.tgz",
-			"integrity": "sha512-WgjNCXYv7ZbtStIap1+tz4pd2zwz0XYN//OILwEY6dINIFLVizK1iWdu+ZtUURL/OKnp8Lv2w8FBds8YihzX7Q==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-1.4.1.tgz",
+			"integrity": "sha512-YWf5zeR6SWtqZmCnuYs4a+ZJetj8NT4yfBMPXekWHW4L3144jM+J2AWagQVejB0FwCqjEUP9l8o4hg1rPDfQlg==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "0.0.39",
-				"@types/node": "*"
+				"@types/node": "^11.9.5",
+				"acorn": "^6.1.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"dev": true
+				}
 			}
 		},
 		"rsvp": {

--- a/packages/apollo-link-schema/package-lock.json
+++ b/packages/apollo-link-schema/package-lock.json
@@ -404,12 +404,10 @@
 			}
 		},
 		"apollo-link": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.7.tgz",
-			"integrity": "sha512-GXHBF5KTb9xndOnHPo6Z4uxjjs8Ce7R+kkm5MXFPMeDEa7QzBOGgAe9/zudWDPjSD0OtYJ20wyY+5R0MYq+lCQ==",
-			"dev": true,
+			"version": "file:../apollo-link",
 			"requires": {
-				"zen-observable-ts": "^0.8.14"
+				"tslib": "^1.9.3",
+				"zen-observable-ts": "file:../zen-observable-ts"
 			}
 		},
 		"apollo-utilities": {
@@ -2426,6 +2424,17 @@
 				"deprecated-decorator": "^0.1.6",
 				"iterall": "^1.1.3",
 				"uuid": "^3.1.0"
+			},
+			"dependencies": {
+				"apollo-link": {
+					"version": "1.2.8",
+					"resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.8.tgz",
+					"integrity": "sha512-lfzGRxhK9RmiH3HPFi7TIEBhhDY9M5a2ZDnllcfy5QDk7cCQHQ1WQArcw1FK0g1B+mV4Kl72DSrlvZHZJEolrA==",
+					"dev": true,
+					"requires": {
+						"zen-observable-ts": "^0.8.15"
+					}
+				}
 			}
 		},
 		"growly": {
@@ -5785,6 +5794,7 @@
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
 			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"commander": "~2.17.1",
 				"source-map": "~0.6.1"
@@ -5794,7 +5804,8 @@
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -6159,9 +6170,9 @@
 			"dev": true
 		},
 		"zen-observable-ts": {
-			"version": "0.8.14",
-			"resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.14.tgz",
-			"integrity": "sha512-yAkb3KkXFa0Dx5A7CvQC0Gj8ycixrLmbr2UZjHgS4FlV5bFwP5artbJTJepETO/DKKfLJ2JVAZrrmNJ4APjdmA==",
+			"version": "0.8.15",
+			"resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.15.tgz",
+			"integrity": "sha512-sXKPWiw6JszNEkRv5dQ+lQCttyjHM2Iks74QU5NP8mMPS/NrzTlHDr780gf/wOBqmHkPO6NCLMlsa+fAQ8VE8w==",
 			"dev": true,
 			"requires": {
 				"zen-observable": "^0.8.0"

--- a/packages/apollo-link-schema/package.json
+++ b/packages/apollo-link-schema/package.json
@@ -36,7 +36,7 @@
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
-    "apollo-link": "^1.2.8",
+    "apollo-link": "file:../apollo-link",
     "tslib": "^1.9.3"
   },
   "peerDependencies": {

--- a/packages/apollo-link-schema/package.json
+++ b/packages/apollo-link-schema/package.json
@@ -49,7 +49,7 @@
     "graphql-tools": "2.24.0",
     "jest": "22.4.4",
     "rimraf": "2.6.3",
-    "rollup": "^1.4.1",
+    "rollup": "1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3"

--- a/packages/apollo-link-schema/package.json
+++ b/packages/apollo-link-schema/package.json
@@ -30,9 +30,8 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepare": "npm run lint && npm run build",
     "prepublishOnly": "npm run clean && npm run build",
-    "test": "jest",
+    "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {

--- a/packages/apollo-link-schema/package.json
+++ b/packages/apollo-link-schema/package.json
@@ -49,7 +49,7 @@
     "graphql-tools": "2.24.0",
     "jest": "22.4.4",
     "rimraf": "2.6.3",
-    "rollup": "0.68.2",
+    "rollup": "^1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3"

--- a/packages/apollo-link-schema/package.json
+++ b/packages/apollo-link-schema/package.json
@@ -27,7 +27,7 @@
     "build": "tsc && rollup -c",
     "clean": "rimraf lib/* && rimraf coverage/*",
     "coverage": "jest --coverage",
-    "filesize": "npm run build",
+    "filesize": "../../scripts/minify",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
     "prepare": "npm run build",

--- a/packages/apollo-link-schema/package.json
+++ b/packages/apollo-link-schema/package.json
@@ -30,7 +30,7 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepublishOnly": "npm run clean && npm run build",
+    "prepare": "npm run build",
     "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },

--- a/packages/apollo-link-ws/package-lock.json
+++ b/packages/apollo-link-ws/package-lock.json
@@ -403,6 +403,13 @@
 				}
 			}
 		},
+		"apollo-link": {
+			"version": "file:../apollo-link",
+			"requires": {
+				"tslib": "^1.9.3",
+				"zen-observable-ts": "file:../zen-observable-ts"
+			}
+		},
 		"append-transform": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
@@ -5778,6 +5785,7 @@
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
 			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"commander": "~2.17.1",
 				"source-map": "~0.6.1"
@@ -5787,7 +5795,8 @@
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/packages/apollo-link-ws/package-lock.json
+++ b/packages/apollo-link-ws/package-lock.json
@@ -51,9 +51,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.12.18",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-			"integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+			"version": "11.10.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.4.tgz",
+			"integrity": "sha512-wa09itaLE8L705aXd8F80jnFpxz3Y1/KRHfKsYL2bPc0XF+wEWu8sR9n5bmeu8Ba1N9z2GRNzm/YdHcghLkLKg==",
 			"dev": true
 		},
 		"abab": {
@@ -4793,13 +4793,22 @@
 			}
 		},
 		"rollup": {
-			"version": "0.68.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.68.2.tgz",
-			"integrity": "sha512-WgjNCXYv7ZbtStIap1+tz4pd2zwz0XYN//OILwEY6dINIFLVizK1iWdu+ZtUURL/OKnp8Lv2w8FBds8YihzX7Q==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-1.4.1.tgz",
+			"integrity": "sha512-YWf5zeR6SWtqZmCnuYs4a+ZJetj8NT4yfBMPXekWHW4L3144jM+J2AWagQVejB0FwCqjEUP9l8o4hg1rPDfQlg==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "0.0.39",
-				"@types/node": "*"
+				"@types/node": "^11.9.5",
+				"acorn": "^6.1.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"dev": true
+				}
 			}
 		},
 		"rsvp": {

--- a/packages/apollo-link-ws/package.json
+++ b/packages/apollo-link-ws/package.json
@@ -28,7 +28,7 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepublishOnly": "npm run clean && npm run build",
+    "prepare": "npm run build",
     "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },

--- a/packages/apollo-link-ws/package.json
+++ b/packages/apollo-link-ws/package.json
@@ -46,7 +46,7 @@
     "graphql-tag": "2.10.1",
     "jest": "22.4.4",
     "rimraf": "2.6.3",
-    "rollup": "^1.4.1",
+    "rollup": "1.4.1",
     "subscriptions-transport-ws": "0.9.15",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",

--- a/packages/apollo-link-ws/package.json
+++ b/packages/apollo-link-ws/package.json
@@ -46,7 +46,7 @@
     "graphql-tag": "2.10.1",
     "jest": "22.4.4",
     "rimraf": "2.6.3",
-    "rollup": "0.68.2",
+    "rollup": "^1.4.1",
     "subscriptions-transport-ws": "0.9.15",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",

--- a/packages/apollo-link-ws/package.json
+++ b/packages/apollo-link-ws/package.json
@@ -25,7 +25,7 @@
     "build": "tsc && rollup -c",
     "clean": "rimraf lib/* && rimraf coverage/*",
     "coverage": "jest --coverage",
-    "filesize": "npm run build",
+    "filesize": "../../scripts/minify",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
     "prepare": "npm run build",

--- a/packages/apollo-link-ws/package.json
+++ b/packages/apollo-link-ws/package.json
@@ -34,7 +34,7 @@
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
-    "apollo-link": "^1.2.8",
+    "apollo-link": "file:../apollo-link",
     "tslib": "^1.9.3"
   },
   "peerDependencies": {

--- a/packages/apollo-link-ws/package.json
+++ b/packages/apollo-link-ws/package.json
@@ -28,9 +28,8 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepare": "npm run lint && npm run build",
     "prepublishOnly": "npm run clean && npm run build",
-    "test": "jest",
+    "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {

--- a/packages/apollo-link/package-lock.json
+++ b/packages/apollo-link/package-lock.json
@@ -5747,6 +5747,7 @@
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
 			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"commander": "~2.17.1",
 				"source-map": "~0.6.1"
@@ -5756,7 +5757,8 @@
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -6112,6 +6114,13 @@
 			"dev": true,
 			"requires": {
 				"camelcase": "^4.1.0"
+			}
+		},
+		"zen-observable-ts": {
+			"version": "file:../zen-observable-ts",
+			"requires": {
+				"tslib": "^1.9.3",
+				"zen-observable": "^0.8.0"
 			}
 		}
 	}

--- a/packages/apollo-link/package-lock.json
+++ b/packages/apollo-link/package-lock.json
@@ -4774,13 +4774,28 @@
 			}
 		},
 		"rollup": {
-			"version": "0.68.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.68.2.tgz",
-			"integrity": "sha512-WgjNCXYv7ZbtStIap1+tz4pd2zwz0XYN//OILwEY6dINIFLVizK1iWdu+ZtUURL/OKnp8Lv2w8FBds8YihzX7Q==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-1.4.1.tgz",
+			"integrity": "sha512-YWf5zeR6SWtqZmCnuYs4a+ZJetj8NT4yfBMPXekWHW4L3144jM+J2AWagQVejB0FwCqjEUP9l8o4hg1rPDfQlg==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "0.0.39",
-				"@types/node": "*"
+				"@types/node": "^11.9.5",
+				"acorn": "^6.1.1"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "11.10.4",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.4.tgz",
+					"integrity": "sha512-wa09itaLE8L705aXd8F80jnFpxz3Y1/KRHfKsYL2bPc0XF+wEWu8sR9n5bmeu8Ba1N9z2GRNzm/YdHcghLkLKg==",
+					"dev": true
+				},
+				"acorn": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"dev": true
+				}
 			}
 		},
 		"rsvp": {

--- a/packages/apollo-link/package.json
+++ b/packages/apollo-link/package.json
@@ -28,7 +28,7 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepublishOnly": "npm run clean && npm run build",
+    "prepare": "npm run build",
     "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },

--- a/packages/apollo-link/package.json
+++ b/packages/apollo-link/package.json
@@ -47,7 +47,7 @@
     "graphql-tag": "2.10.1",
     "jest": "22.4.4",
     "rimraf": "2.6.3",
-    "rollup": "^1.4.1",
+    "rollup": "1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3"

--- a/packages/apollo-link/package.json
+++ b/packages/apollo-link/package.json
@@ -25,7 +25,7 @@
     "build": "tsc && rollup -c",
     "clean": "rimraf lib/* && rimraf coverage/*",
     "coverage": "jest --coverage",
-    "filesize": "npm run build",
+    "filesize": "../../scripts/minify",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
     "prepare": "npm run build",

--- a/packages/apollo-link/package.json
+++ b/packages/apollo-link/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "tslib": "^1.9.3",
-    "zen-observable-ts": "^0.8.15"
+    "zen-observable-ts": "file:../zen-observable-ts"
   },
   "peerDependencies": {
     "graphql": "^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0"

--- a/packages/apollo-link/package.json
+++ b/packages/apollo-link/package.json
@@ -47,7 +47,7 @@
     "graphql-tag": "2.10.1",
     "jest": "22.4.4",
     "rimraf": "2.6.3",
-    "rollup": "0.68.2",
+    "rollup": "^1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3"

--- a/packages/apollo-link/package.json
+++ b/packages/apollo-link/package.json
@@ -28,9 +28,8 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepare": "npm run lint && npm run build",
     "prepublishOnly": "npm run clean && npm run build",
-    "test": "jest",
+    "test": "npm run lint && jest",
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {

--- a/packages/zen-observable-ts/package-lock.json
+++ b/packages/zen-observable-ts/package-lock.json
@@ -45,9 +45,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.12.18",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-			"integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+			"version": "11.10.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.4.tgz",
+			"integrity": "sha512-wa09itaLE8L705aXd8F80jnFpxz3Y1/KRHfKsYL2bPc0XF+wEWu8sR9n5bmeu8Ba1N9z2GRNzm/YdHcghLkLKg==",
 			"dev": true
 		},
 		"abab": {
@@ -4747,13 +4747,22 @@
 			}
 		},
 		"rollup": {
-			"version": "0.68.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.68.2.tgz",
-			"integrity": "sha512-WgjNCXYv7ZbtStIap1+tz4pd2zwz0XYN//OILwEY6dINIFLVizK1iWdu+ZtUURL/OKnp8Lv2w8FBds8YihzX7Q==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-1.4.1.tgz",
+			"integrity": "sha512-YWf5zeR6SWtqZmCnuYs4a+ZJetj8NT4yfBMPXekWHW4L3144jM+J2AWagQVejB0FwCqjEUP9l8o4hg1rPDfQlg==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "0.0.39",
-				"@types/node": "*"
+				"@types/node": "^11.9.5",
+				"acorn": "^6.1.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"dev": true
+				}
 			}
 		},
 		"rsvp": {

--- a/packages/zen-observable-ts/package-lock.json
+++ b/packages/zen-observable-ts/package-lock.json
@@ -5720,6 +5720,7 @@
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
 			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"commander": "~2.17.1",
 				"source-map": "~0.6.1"
@@ -5729,7 +5730,8 @@
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/packages/zen-observable-ts/package.json
+++ b/packages/zen-observable-ts/package.json
@@ -23,7 +23,7 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepublishOnly": "npm run clean && npm run build",
+    "prepare": "npm run build",
     "test": "npm run lint && jest",
     "watch": "tsc -w -p ."
   },

--- a/packages/zen-observable-ts/package.json
+++ b/packages/zen-observable-ts/package.json
@@ -31,7 +31,7 @@
     "@types/jest": "22.2.3",
     "jest": "22.4.4",
     "rimraf": "2.6.3",
-    "rollup": "0.68.2",
+    "rollup": "^1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3"

--- a/packages/zen-observable-ts/package.json
+++ b/packages/zen-observable-ts/package.json
@@ -20,7 +20,7 @@
     "build": "tsc && rollup -c",
     "clean": "rimraf lib/* && rimraf coverage/*",
     "coverage": "jest --coverage",
-    "filesize": "npm run build",
+    "filesize": "../../scripts/minify",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
     "prepare": "npm run build",

--- a/packages/zen-observable-ts/package.json
+++ b/packages/zen-observable-ts/package.json
@@ -23,9 +23,8 @@
     "filesize": "npm run build",
     "lint": "tslint -c \"../../tslint.json\" -p tsconfig.json -c ../../tslint.json src/*.ts",
     "prebuild": "npm run clean",
-    "prepare": "npm run lint && npm run build",
     "prepublishOnly": "npm run clean && npm run build",
-    "test": "jest",
+    "test": "npm run lint && jest",
     "watch": "tsc -w -p ."
   },
   "devDependencies": {

--- a/packages/zen-observable-ts/package.json
+++ b/packages/zen-observable-ts/package.json
@@ -31,7 +31,7 @@
     "@types/jest": "22.2.3",
     "jest": "22.4.4",
     "rimraf": "2.6.3",
-    "rollup": "^1.4.1",
+    "rollup": "1.4.1",
     "ts-jest": "22.4.6",
     "tslint": "5.13.0",
     "typescript": "3.0.3"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,6 @@ import sourcemaps from 'rollup-plugin-sourcemaps';
 import node from 'rollup-plugin-node-resolve';
 import typescript from 'typescript';
 import typescriptPlugin from 'rollup-plugin-typescript2';
-import { terser as minify } from 'rollup-plugin-terser';
 
 export const globals = {
   // Apollo
@@ -76,25 +75,13 @@ export default name => [
   {
     input: 'lib/bundle.esm.js',
     output: {
-      file: 'lib/bundle.min.js',
+      file: 'lib/bundle.cjs.js',
       format: 'cjs',
       globals,
+      sourcemap: true,
     },
     external: Object.keys(globals),
     onwarn,
-    plugins: [
-      minify({
-        mangle: {
-          toplevel: true,
-        },
-        compress: {
-          dead_code: true,
-          global_defs: {
-            "@process.env.NODE_ENV": JSON.stringify("production"),
-          },
-        },
-      }),
-    ],
   }
 ];
 

--- a/scripts/minify
+++ b/scripts/minify
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const { minify } = require("terser");
+const sourcePath = path.join("lib", "bundle.cjs.js");
+const outputPath = path.join("lib", "bundle.min.js");
+
+const source = fs.readFileSync(sourcePath, "utf8");
+const result = minify(source, {
+  mangle: {
+    toplevel: true
+  },
+  compress: {
+    dead_code: true,
+    global_defs: {
+      "@process.env.NODE_ENV": JSON.stringify("production")
+    }
+  }
+});
+
+if (result.error) {
+  throw result.error;
+}
+
+fs.writeFileSync(outputPath, result.code, "utf8");
+
+console.log("minified", sourcePath, "=>", outputPath);


### PR DESCRIPTION
We're still seeing intermittent out-of-memory failures in our Circle CI test (e.g. https://circleci.com/gh/apollographql/apollo-link/28075), which seem to have gotten worse since I merged https://github.com/apollographql/apollo-link/pull/959.

This PR is an attempt to simplify our npm scripts so that they don't use as much memory, by using `file:...` dependencies instead of `lerna link`, and simplifying the `prepare` scripts of the child packages. It may not be enough by itself, but I think it's a step in the right direction.