### PR TITLE
Reduce bundlesize limits to reflect recent measurement changes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,47 +25,47 @@
     {
       "name": "apollo-link",
       "path": "./packages/apollo-link/lib/bundle.min.js",
-      "maxSize": "3 Kb"
+      "maxSize": "1.3 Kb"
     },
     {
       "name": "apollo-link-batch",
       "path": "./packages/apollo-link-batch/lib/bundle.min.js",
-      "maxSize": "1.5 Kb"
+      "maxSize": "1 Kb"
     },
     {
       "name": "apollo-link-batch-http",
       "path": "./packages/apollo-link-batch-http/lib/bundle.min.js",
-      "maxSize": "6.8 Kb"
+      "maxSize": "1 Kb"
     },
     {
       "name": "apollo-link-dedup",
       "path": "./packages/apollo-link-dedup/lib/bundle.min.js",
-      "maxSize": "3 Kb"
+      "maxSize": "535 B"
     },
     {
       "name": "apollo-link-error",
       "path": "./packages/apollo-link-error/lib/bundle.min.js",
-      "maxSize": "1 Kb"
+      "maxSize": "465 B"
     },
     {
       "name": "apollo-link-http",
       "path": "./packages/apollo-link-http/lib/bundle.min.js",
-      "maxSize": "6 Kb"
+      "maxSize": "1.15 Kb"
     },
     {
       "name": "apollo-link-polling",
       "path": "./packages/apollo-link-polling/lib/bundle.min.js",
-      "maxSize": "1 Kb"
+      "maxSize": "350 B"
     },
     {
       "name": "apollo-link-retry",
       "path": "./packages/apollo-link-retry/lib/bundle.min.js",
-      "maxSize": "2.5 Kb"
+      "maxSize": "1.15 Kb"
     },
     {
       "name": "apollo-link-ws",
       "path": "./packages/apollo-link-ws/lib/bundle.min.js",
-      "maxSize": "10 Kb"
+      "maxSize": "300 B"
     }
   ],
   "jest": {


### PR DESCRIPTION
Although it's possible that shipping ESM code via the "module" field of `package.json` may have reduced the size of these packages, the primary reason for the very large reduction in package sizes is that we're no longer bundling in the dependencies, so the new sizes reflect just the packages themselves.

Including dependencies in per-package size measurements is misleading because most apps use multiple `apollo-link-*` packages, so shared dependencies will be included only once in the bundle, and thus should not be counted as part of each individual package's size.

Fundamentally, measuring bundle size on a per-package basis doesn't make a whole lot of sense. Instead, we should use an example application that uses a typical/representative set of Apollo packages, and bundles everything together using a modern bundling tool.