### PR TITLE
enable webpack tree-shaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Remove the docs CI step. <br/>
   [@JoviDeCroock](https://github.com/JoviDeCroock) in [#938](https://github.com/apollographql/apollo-link/pull/938)
+- Enable tree-shaking in webpack. <br/>
+  [@JoviDeCroock](https://github.com/JoviDeCroock) in [#967](https://github.com/apollographql/apollo-link/pull/967)
 
 ### docs
 

--- a/packages/apollo-link-batch-http/package.json
+++ b/packages/apollo-link-batch-http/package.json
@@ -13,6 +13,7 @@
   "main": "./lib/index.js",
   "module": "./lib/bundle.esm.js",
   "typings": "./lib/index.d.ts",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/apollographql/apollo-link.git"

--- a/packages/apollo-link-batch/package.json
+++ b/packages/apollo-link-batch/package.json
@@ -13,6 +13,7 @@
   "main": "./lib/index.js",
   "module": "./lib/bundle.esm.js",
   "typings": "./lib/index.d.ts",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/apollographql/apollo-link.git"

--- a/packages/apollo-link-context/package.json
+++ b/packages/apollo-link-context/package.json
@@ -7,6 +7,7 @@
   "main": "./lib/index.js",
   "module": "./lib/bundle.esm.js",
   "typings": "./lib/index.d.ts",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/apollographql/apollo-link.git"

--- a/packages/apollo-link-dedup/package.json
+++ b/packages/apollo-link-dedup/package.json
@@ -13,6 +13,7 @@
   "main": "./lib/index.js",
   "module": "./lib/bundle.esm.js",
   "typings": "./lib/index.d.ts",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/apollographql/apollo-link.git"

--- a/packages/apollo-link-error/package.json
+++ b/packages/apollo-link-error/package.json
@@ -7,6 +7,7 @@
   "main": "./lib/index.js",
   "module": "./lib/bundle.esm.js",
   "typings": "./lib/index.d.ts",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/apollographql/apollo-link.git"

--- a/packages/apollo-link-http-common/package.json
+++ b/packages/apollo-link-http-common/package.json
@@ -5,6 +5,7 @@
   "main": "./lib/index.js",
   "module": "./lib/bundle.esm.js",
   "typings": "./lib/index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "build": "tsc && rollup -c",
     "clean": "rimraf lib/* && rimraf coverage/*",

--- a/packages/apollo-link-http/package.json
+++ b/packages/apollo-link-http/package.json
@@ -14,6 +14,7 @@
   "main": "./lib/index.js",
   "module": "./lib/bundle.esm.js",
   "typings": "./lib/index.d.ts",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/apollographql/apollo-link.git"

--- a/packages/apollo-link-polling/package.json
+++ b/packages/apollo-link-polling/package.json
@@ -14,6 +14,7 @@
   "main": "./lib/index.js",
   "module": "./lib/bundle.esm.js",
   "typings": "./lib/index.d.ts",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/apollographql/apollo-link.git"

--- a/packages/apollo-link-retry/package.json
+++ b/packages/apollo-link-retry/package.json
@@ -13,6 +13,7 @@
   "main": "./lib/index.js",
   "module": "./lib/bundle.esm.js",
   "typings": "./lib/index.d.ts",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/apollographql/apollo-link.git"

--- a/packages/apollo-link-schema/package.json
+++ b/packages/apollo-link-schema/package.json
@@ -15,6 +15,7 @@
   "main": "./lib/index.js",
   "module": "./lib/bundle.esm.js",
   "typings": "./lib/index.d.ts",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/apollographql/apollo-link.git"

--- a/packages/apollo-link-ws/package.json
+++ b/packages/apollo-link-ws/package.json
@@ -13,6 +13,7 @@
   "main": "./lib/index.js",
   "module": "./lib/bundle.esm.js",
   "typings": "./lib/index.d.ts",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/apollographql/apollo-link.git"

--- a/packages/apollo-link/package.json
+++ b/packages/apollo-link/package.json
@@ -13,6 +13,7 @@
   "main": "./lib/index.js",
   "module": "./lib/bundle.esm.js",
   "typings": "./lib/index.d.ts",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/apollographql/apollo-link.git"

--- a/packages/zen-observable-ts/package.json
+++ b/packages/zen-observable-ts/package.json
@@ -8,6 +8,7 @@
   "main": "./lib/index.js",
   "module": "./lib/bundle.esm.js",
   "typings": "./lib/index.d.ts",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/apollographql/apollo-link.git"


### PR DESCRIPTION
- [x] Update CHANGELOG.md with your change

I can't really test this but webpack relies on this field to know if it is tree-shakeable.

I also plan to unify this repository a bit more, same layout in package json etc, and maybe introduce some way of keeping this uniform.