### PR TITLE
Avoid importing graphql/language/printer for getKey.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 **Note:** This is a cumulative changelog that outlines all of the Apollo Link project child package changes that were bundled into a release on a specific day.
 
+## vNEXT
+
+### apollo-link
+
+- Avoid importing `graphql/language/printer` for `getKey`. <br/>
+  [@benjamn](https://github.com/benjamn) in [#992](https://github.com/apollographql/apollo-link/pull/992)
+
+
 ## 2019-03-14
 
 ### apollo-link-dedup 1.0.18

--- a/packages/apollo-link/src/linkUtils.ts
+++ b/packages/apollo-link/src/linkUtils.ts
@@ -1,5 +1,4 @@
 import Observable from 'zen-observable-ts';
-import { print } from 'graphql/language/printer';
 
 import { GraphQLRequest, Operation } from './types';
 import { ApolloLink } from './link';
@@ -128,9 +127,8 @@ export function createOperation(
 }
 
 export function getKey(operation: GraphQLRequest) {
-  // XXX we're assuming here that variables will be serialized in the same order.
-  // that might not always be true
-  return `${print(operation.query)}|${JSON.stringify(operation.variables)}|${
-    operation.operationName
-  }`;
+  // XXX We're assuming here that query and variables will be serialized in
+  // the same order, which might not always be true.
+  const { query, variables, operationName } = operation;
+  return JSON.stringify([operationName, query, variables]);
 }


### PR DESCRIPTION
We have been slowly working to remove all uses of the graphql-js `print` function from Apollo client packages, since the printer weighs in at 4.86KB minified (without gzip); and, while that's not terribly huge, printing large queries takes precious time that we can usually avoid.

This particular usage is relatively easy to replace with `JSON.stringify`. This should be faster than actually printing the query, and we can serialize everything (`query`, `variables`, and `operationName`) with just one call to `JSON.stringify`, without manually joining the fragments with '|'.

It's reasonable to be concerned about the stability of `JSON.stringify`, since equivalent queries could have slightly different property ordering, but the official GraphQL printer doesn't make any guarantees about the stability or canonicality of the resulting string, either. The important thing is that `===` identical queries have the same string form, and that's definitely true here.

After this change, there is just [one remaining call to `print` in `apollo-link-http-common`](https://github.com/apollographql/apollo-link/blob/ed1800b4261566e91906cdb9cc45c7d004393175/packages/apollo-link-http-common/src/index.ts#L239), which seems a bit harder to replace, but at least you have the option of using something other than apollo-link-http if you really care about not reprinting the query before sending it to the server.