### PR TITLE
Move redirects to public dir

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   base    = "docs/"
   publish = "docs/public/"
-  command = "gatsby build --prefix-paths && mkdir -p docs/link && mv public/* docs/link && mv docs public/"
+  command = "gatsby build --prefix-paths && mkdir -p docs/link && mv public/* docs/link && mv docs public/ && mv public/docs/link/_redirects public"
 [build.environment]
   NPM_VERSION = "6"


### PR DESCRIPTION
Moves `_redirects` from `public/docs/link/_redirects` to `public/_redirects`