### PR TITLE
Do not throw JSON parse error for not successful responses

### DIFF
--- a/packages/apollo-link-http-common/src/__tests__/index.ts
+++ b/packages/apollo-link-http-common/src/__tests__/index.ts
@@ -28,7 +28,7 @@ describe('Common Http functions', () => {
     const operations = [createOperation({}, { query })];
 
     it('throws a parse error with a status code on unparsable response', done => {
-      const status = 400;
+      const status = 200;
       fetchMock.mock('begin:error', status);
       fetch('error')
         .then(parseAndCheckHttpResponse(operations))

--- a/packages/apollo-link-http-common/src/__tests__/index.ts
+++ b/packages/apollo-link-http-common/src/__tests__/index.ts
@@ -27,6 +27,22 @@ describe('Common Http functions', () => {
 
     const operations = [createOperation({}, { query })];
 
+    it('throws a server error with a status code on not successful response', done => {
+      const status = 400;
+      fetchMock.mock('begin:error', status);
+      fetch('error')
+        .then(parseAndCheckHttpResponse(operations))
+        .then(done.fail)
+        .catch(e => {
+          expect(e.statusCode).toBe(status);
+          expect(e.name).toBe('ServerError');
+          expect(e).toHaveProperty('response');
+          expect(e).toHaveProperty('result');
+          done();
+        })
+        .catch(done.fail);
+    });
+
     it('throws a parse error with a status code on unparsable response', done => {
       const status = 200;
       fetchMock.mock('begin:error', status);


### PR DESCRIPTION
Right now if graphql server response is not successful and the response does not contain proper JSON (which I think is often the case) the following error is thrown `Unexpected token x in JSON at position 0` 

The issue was already described here https://github.com/apollographql/apollo-client/issues/2770

I believe that if response status is != 2xx the proper error to throw is `Response not successful: Received status code xyz` no matter what response body is.
TODO:

- [ ] Make sure all of new logic is covered by tests and passes linting
- [ ] Update CHANGELOG.md with your change

