### PR TITLE
Update peerDependencies to include `qs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,13 @@
 **Note:** This is a cumulative changelog that outlines all of the Apollo Link project child package changes that were bundled into a release on a specific day.
 
-## 2019-05-13
-
-### apollo-link
-
-- Documentation updates.  <br/>
-  [@jsjoeio](https://github.com/jsjoeio) in [#1044](https://github.com/apollographql/apollo-link/pull/1044)  <br />
-
 ## vNEXT
 
 ### apollo-link
 
 - Avoid importing `graphql/language/printer` for `getKey`. <br/>
   [@benjamn](https://github.com/benjamn) in [#992](https://github.com/apollographql/apollo-link/pull/992)
+- Documentation updates.  <br/>
+  [@jsjoeio](https://github.com/jsjoeio) in [#1044](https://github.com/apollographql/apollo-link/pull/1044)  <br />
 
 
 ## 2019-03-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 **Note:** This is a cumulative changelog that outlines all of the Apollo Link project child package changes that were bundled into a release on a specific day.
 
+## 2019-05-13
+
+### apollo-link
+
+- Documentation updates.  <br/>
+  [@jsjoeio](https://github.com/jsjoeio) in [#1044](https://github.com/apollographql/apollo-link/pull/1044)  <br />
+
 ## vNEXT
 
 ### apollo-link

--- a/docs/source/links/rest.md
+++ b/docs/source/links/rest.md
@@ -31,7 +31,7 @@ npm install --save apollo-cache-inmemory
 Then it is time to install our link and its `peerDependencies`:
 
 ```bash
-npm install --save apollo-link-rest apollo-link graphql graphql-anywhere
+npm install --save apollo-link-rest apollo-link graphql graphql-anywhere qs
 ```
 
 After this, you are ready to setup your apollo client:


### PR DESCRIPTION
Addresses issue https://github.com/apollographql/apollo-link-rest/pull/187#issuecomment-491660746

`qs` is a peer dependency needed by `apollo-link-rest` so this updates the official docs to reflect that. 

TODO:

- [X] Make sure all of new logic is covered by tests and passes linting
- [x] Update CHANGELOG.md with your change

