### PR TITLE
feat:(apollo-link-retry): Handle retries for GraphQL errors in the response

### DIFF
--- a/packages/apollo-link-retry/README.md
+++ b/packages/apollo-link-retry/README.md
@@ -3,7 +3,7 @@ title: apollo-link-retry
 description: Attempt an operation multiple times if it fails due to network or server errors.
 ---
 
-Sometimes, you're in an unreliable situation but you would rather wait longer than explicitly fail an operation. `apollo-link-retry` provides exponential backoff, and jitters delays between attempts by default. It does not (currently) handle retries for GraphQL errors in the response, only for network errors.
+Sometimes, you're in an unreliable situation but you would rather wait longer than explicitly fail an operation. `apollo-link-retry` provides exponential backoff, and jitters delays between attempts by default. It supports retries for both network errors and GraphQL errors in the response.
 
 One such use case is to hold on to a request while a network connection is offline and retry until it comes back online.
 


### PR DESCRIPTION
Resolves https://github.com/apollographql/apollo-link/issues/541

TODO:

- [ ] Make sure all of new logic is covered by tests and passes linting
- [ ] Update CHANGELOG.md with your change

Changes at lines 97 and 102 in `retryLink.ts` are obviously wrong. When I do not disable handling `onComplete`, the query does not get retried because the observable calls `complete` even though the response contains an error.
I just disabled these to test and the retry logic works exactly as expected (for POC) but I'm a little blocked on fixing the `complete` handling.

Anyone would care to help me a little? I have "Allow edits from maintainers" on, if so. Thank you in advance, we would _love_ to get this feature 🙏