### PR TITLE
Mark RequestHandler forward argument as required

### DIFF
--- a/packages/apollo-link/src/types.ts
+++ b/packages/apollo-link/src/types.ts
@@ -33,5 +33,5 @@ export type FetchResult<
 export type NextLink = (operation: Operation) => Observable<FetchResult>;
 export type RequestHandler = (
   operation: Operation,
-  forward?: NextLink,
+  forward: NextLink,
 ) => Observable<FetchResult> | null;


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
I'm just blindly changing this and mainly wondering what, if anything, requires `forward` to be optional.

The example at https://www.apollographql.com/docs/link/stateless/#stateless-links
```ts
const consoleLink = new ApolloLink((operation, forward) => {
  console.log(`starting request for ${operation.operationName}`);
  return forward(operation).map(data => {
    console.log(`ending request for ${operation.operationName}`);
    return data;
  });
});
```
is throwing a type error with forward:
<img width="552" alt="Screen Shot 2019-06-17 at 1 16 57 PM" src="https://user-images.githubusercontent.com/756501/59633846-48de4880-9102-11e9-9e17-f82c4ee4077a.png">

Can `forward` actually be `undefined` at runtime? `RequestHandler` requires a return value of `Observable<FetchResult> | null` so if I add a null check in my own code, I have to explicitly return `null` instead of `undefined` which is annoying:
```ts
const consoleLink = new ApolloLink((operation, forward) => {
  console.log(`starting request for ${operation.operationName}`);
  return forward
    ? forward(operation).map(data => {
        console.log(`ending request for ${operation.operationName}`);
        return data;
      })
    : null;
});
```
If users need to handle `undefined` here for some reason, you can close this but can we update the examples with the needed null check and an explanation for why `forward` might not be available? If this is always defined let's update the type 😃 Thanks!

TODO:

- [ ] Make sure all of new logic is covered by tests and passes linting
- [ ] Update CHANGELOG.md with your change

