### PR TITLE
Remove reference to GlobalFetch in Typescript

### DIFF
--- a/packages/apollo-link-http-common/src/index.ts
+++ b/packages/apollo-link-http-common/src/index.ts
@@ -71,7 +71,7 @@ export interface HttpOptions {
   /**
    * A `fetch`-compatible API to use when making requests.
    */
-  fetch?: GlobalFetch['fetch'];
+  fetch?: WindowOrWorkerGlobalScope['fetch'];
 
   /**
    * An object representing values to be sent as headers on the request.
@@ -171,7 +171,7 @@ export const parseAndCheckHttpResponse = operations => (response: Response) => {
   );
 };
 
-export const checkFetcher = (fetcher: GlobalFetch['fetch']) => {
+export const checkFetcher = (fetcher: WindowOrWorkerGlobalScope['fetch']) => {
   if (!fetcher && typeof fetch === 'undefined') {
     let library: string = 'unfetch';
     if (typeof window === 'undefined') library = 'node-fetch';


### PR DESCRIPTION
Fixes compilation of apollo-link-http-common in the upcoming Typescript 3.6.

Fixes #1094

There is no new test for this -- if it builds then it works with whatever version of Typescript is on CI; if apollo-link doesn't already test with multiple versions of TS then I don't think this is the place to make that happen.