### PR TITLE
Allow null in `ApolloLink.from` array 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 **Note:** This is a cumulative changelog that outlines all of the Apollo Link project child package changes that were bundled into a release on a specific day.
 
+## 2019-07-06
+
+### apollo-link vNext
+
+- Add `useContext` option for `apollo-link-dedup`. Uses context config as part
+  of uniqueness key when deduping requests.  <br/>
+  [@BeeeQueue](https://github.com/BeeeQueue) in [#957](https://github.com/apollographql/apollo-link/pull/957) <br />
+
 ## 2019-06-14
 
 ### apollo-link 1.2.12

--- a/packages/apollo-link/src/__tests__/link.ts
+++ b/packages/apollo-link/src/__tests__/link.ts
@@ -420,6 +420,31 @@ describe('Link static library', () => {
       ).not.toThrow();
     });
 
+    it('can handle nulls in array', () => {
+      const data: FetchResult = {
+        data: {
+          hello: 'world',
+        },
+      };
+      const chain = ApolloLink.from([
+        null,
+        undefined,
+        new MockLink(() => Observable.of(data)),
+        null,
+      ]);
+      // Smoke tests execute as a static method
+      const observable = ApolloLink.execute(chain, uniqueOperation);
+      observable.subscribe({
+        next: actualData => {
+          expect(data).toEqual(actualData);
+        },
+        error: () => {
+          throw new Error();
+        },
+        complete: () => done(),
+      });
+    });
+
     it('should receive result of one link', done => {
       const data: FetchResult = {
         data: {

--- a/packages/apollo-link/src/link.ts
+++ b/packages/apollo-link/src/link.ts
@@ -7,6 +7,7 @@ import {
   Operation,
   RequestHandler,
   FetchResult,
+  OptionalApolloLink,
 } from './types';
 
 import {
@@ -25,13 +26,20 @@ function toLink(handler: RequestHandler | ApolloLink) {
   return typeof handler === 'function' ? new ApolloLink(handler) : handler;
 }
 
+function removeNulls(link: OptionalApolloLink) {
+  return !!link;
+}
+
 export function empty(): ApolloLink {
   return new ApolloLink(() => Observable.of());
 }
 
-export function from(links: ApolloLink[]): ApolloLink {
+export function from(links: OptionalApolloLink[]): ApolloLink {
   if (links.length === 0) return empty();
-  return links.map(toLink).reduce((x, y) => x.concat(y));
+  return links
+    .filter(removeNulls)
+    .map(toLink)
+    .reduce((x, y) => x.concat(y));
 }
 
 export function split(

--- a/packages/apollo-link/src/types.ts
+++ b/packages/apollo-link/src/types.ts
@@ -1,7 +1,10 @@
 import Observable from 'zen-observable-ts';
 import { DocumentNode } from 'graphql/language/ast';
 import { ExecutionResult } from 'graphql/execution/execute';
+import { ApolloLink } from './link';
 export { ExecutionResult, DocumentNode };
+
+export type OptionalApolloLink = ApolloLink | undefined | null;
 
 export interface GraphQLRequest {
   query: DocumentNode;


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:
- [x] Make sure all of new logic is covered by tests and passes linting
- [x] Update CHANGELOG.md with your change

This PR allows `null` and `undefined` to be passed in the array passed to `ApolloLink.from()`.

This allows for easier link creation and usage where you want to disable a link's functionality in certain situations. 

An example of this is [`apollo-link-logger`](https://github.com/blackxored/apollo-link-logger) which you most likely don't want running in production. 
Currently each created client has to manually check if it wants to add the link in the environment, and then add it to the array if it does. 

A better solution would be to have the link take a `enabled` option.
Currently if a link wants to do this they still have to return a link to the creation, a link that does nothing but is still run.