### PR TITLE
Remove dead link to apollo-link-state in docs

### DIFF
--- a/packages/apollo-link-schema/README.md
+++ b/packages/apollo-link-schema/README.md
@@ -3,7 +3,7 @@ title: apollo-link-schema
 description: Assists with mocking and server-side rendering
 ---
 
-The schema link provides a [graphql execution environment](http://graphql.org/graphql-js/graphql/#graphql), which allows you to perform GraphQL operations on a provided schema. This type of behavior is commonly used for server-side rendering (SSR) to avoid network calls and mocking data. While the schema link could provide graphql results on the client, currently the graphql execution layer is [too heavy weight](https://bundlephobia.com/result?p=graphql) for practical application. To unify your state management with client-side GraphQL operations, you should use [apollo-link-state](state.html), because it integrates with the Apollo Client cache and is much more lightweight.
+The schema link provides a [graphql execution environment](http://graphql.org/graphql-js/graphql/#graphql), which allows you to perform GraphQL operations on a provided schema. This type of behavior is commonly used for server-side rendering (SSR) to avoid network calls and mocking data. While the schema link could provide graphql results on the client, currently the graphql execution layer is [too heavy weight](https://bundlephobia.com/result?p=graphql) for practical application. To unify your state management with client-side GraphQL operations, you should use [local state management](https://www.apollographql.com/docs/react/essentials/local-state/), because it is already integrated with Apollo Client.
 
 ## Installation
 


### PR DESCRIPTION
The page https://www.apollographql.com/docs/link/links/schema/ currently links to https://www.apollographql.com/docs/link/links/schema/state.html, which does not exist.