### PR TITLE
fix(docs): adjust the order of Link order example

### DIFF
--- a/docs/source/links/rest.md
+++ b/docs/source/links/rest.md
@@ -467,7 +467,7 @@ const httpLink = createHttpLink({ uri: "server.com/graphql" });
 const restLink = new RestLink({ uri: "api.server.com" });
 
 const client = new ApolloClient({
-  link: ApolloLink.from([authLink, restLink, errorLink, retryLink, httpLink]),
+  link: ApolloLink.from([authLink, errorLink, restLink, retryLink, httpLink]),
   // Note: httpLink is terminating so must be last, while retry & error wrap the links to their right
   //       state & context links should happen before (to the left of) restLink.
   cache: new InMemoryCache()


### PR DESCRIPTION
Put errorLink in front of restLink, otherwise it can't catch the error of 403

<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Make sure all of new logic is covered by tests and passes linting
- [ ] Update CHANGELOG.md with your change

