### PR TITLE
Update apollo-link-error docs: stringify locations

### DIFF
--- a/packages/apollo-link-error/README.md
+++ b/packages/apollo-link-error/README.md
@@ -12,7 +12,7 @@ const link = onError(({ graphQLErrors, networkError }) => {
   if (graphQLErrors)
     graphQLErrors.forEach(({ message, locations, path }) =>
       console.log(
-        `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`
+        `[GraphQL error]: Message: ${message}, Location: ${JSON.stringify(locations)}, Path: ${path}`
       )
     );
   if (networkError) console.log(`[Network error]: ${networkError}`);


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
Currently error output will look like `Location: [object Object]`.
After adding the stringify: `Location: [{"line":4,"column":5}]`.
TODO:

- [x] Make sure all of new logic is covered by tests and passes linting
- [ ] Update CHANGELOG.md with your change

