### PR TITLE
Adds missing peer dependency

### DIFF
--- a/packages/apollo-link-error/package.json
+++ b/packages/apollo-link-error/package.json
@@ -32,6 +32,9 @@
     "apollo-link-http-common": "file:../apollo-link-http-common",
     "tslib": "^1.9.3"
   },
+  "peerDependencies": {
+    "graphql": "^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0"
+  },
   "devDependencies": {
     "@types/graphql": "14.2.3",
     "@types/jest": "24.0.22",


### PR DESCRIPTION
`apollo-link-error` has a transitive peer dependency on `graphql` through `apollo-link`, and must be marked as such. Cf my article why [implicit transitive peer dependencies are bad](https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0) 🙂