### PR TITLE
chore: add a link to community links document

### DIFF
--- a/docs/source/links/community.md
+++ b/docs/source/links/community.md
@@ -27,3 +27,4 @@ Thank you to our amazing community members who have created custom Apollo Links!
 * [apollo-link-firebase](https://github.com/Canner/apollo-link-firebase) by [@canner](https://github.com/Canner): Query Firebase with Apollo
 * [apollo-link-computed-property](https://github.com/czystyl/apollo-link-computed-property) by [@czystyl](https://github.com/czystyl): `@computed` directive allows you to create a computed property on the query
 * [apollo-link-segment](https://github.com/hobochild/apollo-link-segment) by [@hobochild](https://github.com/hobochild): Automatically track apollo operations with [segment](https://segment.com/).
+* [apollo-link-fragment-argument](https://github.com/Quramy/apollo-link-fragment-argument) by [@quramy](https://github.com/quramy): Enables to parameterize fragments using `@arguments` and `@argumentDefinitions` directives(inspired from Relay Modern)


### PR DESCRIPTION
Hi. I've created a custom apollo-link, https://github.com/Quramy/apollo-link-fragment-argument . Would you append a link about this to community link docs ?