### PR TITLE
Update link-error docs to reference `response.errors = undefined`

### DIFF
--- a/packages/apollo-link-error/README.md
+++ b/packages/apollo-link-error/README.md
@@ -81,12 +81,12 @@ One caveat is that the errors from the new response from retrying the request do
 
 ## Ignoring errors
 
-If you want to conditionally ignore errors, you can set `response.errors = null;` within the error handler:
+If you want to conditionally ignore errors, you can set `response.errors = undefined;` within the error handler:
 
 ```js
 onError(({ response, operation }) => {
   if (operation.operationName === "IgnoreErrorsQuery") {
-    response.errors = null;
+    response.errors = undefined;
   }
 });
 ```

--- a/packages/apollo-link-error/src/__tests__/index.ts
+++ b/packages/apollo-link-error/src/__tests__/index.ts
@@ -173,7 +173,7 @@ describe('error handling', () => {
     const errorLink = onError(({ graphQLErrors, response }) => {
       expect(graphQLErrors[0].message).toBe('ignore');
       // ignore errors
-      response.errors = null;
+      response.errors = undefined;
       called = true;
     });
 
@@ -188,7 +188,7 @@ describe('error handling', () => {
 
     execute(link, { query }).subscribe({
       next: ({ errors, data }) => {
-        expect(errors).toBe(null);
+        expect(errors).toBe(undefined);
         expect(data).toEqual({ foo: { id: 1 } });
       },
       complete: done,


### PR DESCRIPTION
The docs incorrectly show that `response.error` can be null. However in the graphql-js package that defines `ExecutiionResult` in is is either an array of `GraphQLError` or undefined. Null is not a valid option.

https://github.com/graphql/graphql-js/blob/master/src/execution/execute.d.ts#L52

Issue reference: https://github.com/apollographql/apollo-link/issues/1168

<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Make sure all of new logic is covered by tests and passes linting
- [ ] Update CHANGELOG.md with your change

