### PR TITLE
[Feature] Allow configuration to strip unnecessary characters

### DIFF
--- a/packages/apollo-link-batch-http/README.md
+++ b/packages/apollo-link-batch-http/README.md
@@ -76,10 +76,11 @@ operation.setContext({
 })
 ```
 
-The `http` object on context currently supports two keys:
+The `http` object on context currently supports three keys:
 
 * `includeExtensions`: Send the extensions object for this request.
 * `includeQuery`: Don't send the `query` field for this request.
+* `minifyQuery`: Strip unnecessary characters in the `query` field for this request.
 
 One way to use persisted queries is with [apollo-link-persisted-queries](https://github.com/apollographql/apollo-link-persisted-queries) and [Apollo Engine](https://www.apollographql.com/docs/engine/auto-persisted-queries.html).
 

--- a/packages/apollo-link-http-common/src/__tests__/index.ts
+++ b/packages/apollo-link-http-common/src/__tests__/index.ts
@@ -172,6 +172,14 @@ describe('Common Http functions', () => {
       expect(options.opt).toEqual('hi');
       expect(options.method).toEqual('POST'); //from default
     });
+
+    it('allows to configure to strip unnecessary characters', () => {
+      const { body } = selectHttpOptionsAndBody(
+        createOperation({}, { query }),
+        { http: { includeQuery: true, minifyQuery: true } },
+      );
+      expect(body.query).toBe('query SampleQuery{stub{id}}');
+    });
   });
 
   describe('selectURI', () => {

--- a/packages/apollo-link-http-common/src/index.ts
+++ b/packages/apollo-link-http-common/src/index.ts
@@ -1,5 +1,6 @@
 import { Operation } from 'apollo-link';
 import { print } from 'graphql/language/printer';
+import { stripIgnoredCharacters } from 'graphql/utilities/stripIgnoredCharacters';
 import { InvariantError } from 'ts-invariant';
 
 /*
@@ -32,6 +33,7 @@ export type ClientParseError = InvariantError & {
 export interface HttpQueryOptions {
   includeQuery?: boolean;
   includeExtensions?: boolean;
+  minifyQuery?: boolean;
 }
 
 export interface HttpConfig {
@@ -92,6 +94,7 @@ export interface HttpOptions {
 const defaultHttpOptions: HttpQueryOptions = {
   includeQuery: true,
   includeExtensions: false,
+  minifyQuery: false,
 };
 
 const defaultHeaders = {
@@ -236,7 +239,10 @@ export const selectHttpOptionsAndBody = (
   if (http.includeExtensions) (body as any).extensions = extensions;
 
   // not sending the query (i.e persisted queries)
-  if (http.includeQuery) (body as any).query = print(query);
+  if (http.includeQuery)
+    (body as any).query = http.minifyQuery
+      ? stripIgnoredCharacters(print(query))
+      : print(query);
 
   return {
     options,

--- a/packages/apollo-link-http/README.md
+++ b/packages/apollo-link-http/README.md
@@ -69,10 +69,11 @@ operation.setContext({
 })
 ```
 
-The `http` object on context currently supports two keys:
+The `http` object on context currently supports three keys:
 
 * `includeExtensions`: Send the extensions object for this request.
 * `includeQuery`: Don't send the `query` field for this request.
+* `minifyQuery`: Strip unnecessary characters in the `query` field for this request.
 
 One way to use persisted queries is with [apollo-link-persisted-queries](https://github.com/apollographql/apollo-link-persisted-queries) and [Apollo Engine](https://www.apollographql.com/docs/engine/auto-persisted-queries.html).
 


### PR DESCRIPTION
This is a pull request related to the issue #1079 which adds a new option to remove unnecessary characters in the query field in order to save bandwidth (neglectable?) and cleaner GET queries.

**TODO:**

- [x] Make sure all of new logic is covered by tests and passes linting
- [x] Update CHANGELOG.md with your change
