### PR TITLE
fix: default fetch credentials to 'same-origin'

### DIFF
--- a/packages/apollo-link-http-common/src/__tests__/index.ts
+++ b/packages/apollo-link-http-common/src/__tests__/index.ts
@@ -124,6 +124,7 @@ describe('Common Http functions', () => {
       };
 
       const defaultOptions = {
+        credentials: 'same-origin',
         method: 'POST',
       };
 
@@ -137,6 +138,7 @@ describe('Common Http functions', () => {
       expect(body).not.toHaveProperty('extensions');
 
       expect(options.headers).toEqual(defaultHeaders);
+      expect(options.credentials).toEqual(defaultOptions.credentials);
       expect(options.method).toEqual(defaultOptions.method);
     });
 

--- a/packages/apollo-link-http-common/src/index.ts
+++ b/packages/apollo-link-http-common/src/index.ts
@@ -101,6 +101,7 @@ const defaultHeaders = {
 };
 
 const defaultOptions = {
+  credentials: 'same-origin',
   method: 'POST',
 };
 
@@ -206,6 +207,9 @@ export const selectHttpOptionsAndBody = (
     headers: fallbackConfig.headers,
     credentials: fallbackConfig.credentials,
   };
+  if (!options.credentials && fallbackConfig.options)
+    options.credentials = fallbackConfig.options.credentials;
+
   let http: HttpQueryOptions = fallbackConfig.http;
 
   /*

--- a/packages/apollo-link-http/src/__tests__/httpLink.ts
+++ b/packages/apollo-link-http/src/__tests__/httpLink.ts
@@ -242,6 +242,27 @@ describe('HttpLink', () => {
         }),
       );
     });
+
+    it("defaults to credentials: 'same-origin'", done => {
+      const variables = { params: 'stub' };
+      const link = createHttpLink({
+        uri: 'http://data/',
+      });
+
+      execute(link, {
+        query: sampleMutation,
+        variables,
+      }).subscribe(
+        makeCallback(done, result => {
+          const [uri, options] = fetchMock.lastCall();
+          const { credentials, method, body } = options;
+          expect(body).toBeDefined();
+          expect(credentials).toBe('same-origin');
+          expect(method).toBe('POST');
+          expect(uri).toBe('http://data/');
+        }),
+      );
+    });
   });
 
   it("throws for GET if the variables can't be stringified", done => {


### PR DESCRIPTION
For modern implementations of fetch this is already the default, but in 2017 this wasn't true, so browsers exist in the wild which default to 'omit'.

An example of this would be Firefox 57, if anyone wants to test.

This PR seeks to make things work out-of-the-box. Currently with Apollo Link, you won't get credentials for a small range of browsers - those that natively implemented fetch, but before the spec changed to have credentials default to 'same-origin'. Polyfilled browsers will follow the latest spec, so it's only this small subsection of browsers which will mysteriously fail currently.

<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Make sure all of new logic is covered by tests and passes linting
- [ ] Update CHANGELOG.md with your change

