### PR TITLE
Update "Complete options" example in rest.md

### DIFF
--- a/docs/source/links/rest.md
+++ b/docs/source/links/rest.md
@@ -396,7 +396,7 @@ Here is one way you might customize `RestLink`:
         bodySnippet...
       }
     },
-    defaultSerializer: (data: any, headers: Headers) => {
+    defaultSerializer: (body: any, headers: Headers) => {
       const formData = new FormData();
       for (let key in body) {
         formData.append(key, body[key]);


### PR DESCRIPTION
`body` was not defined in "Complete options" example.

- changed the param `data` to `body` for `defaultSerializer`
