### PR TITLE
Expose subscription client

### DIFF
--- a/packages/apollo-link-ws/src/webSocketLink.ts
+++ b/packages/apollo-link-ws/src/webSocketLink.ts
@@ -28,7 +28,7 @@ export namespace WebSocketLink {
 export import WebSocketParams = WebSocketLink.Configuration;
 
 export class WebSocketLink extends ApolloLink {
-  private subscriptionClient: SubscriptionClient;
+  public subscriptionClient: SubscriptionClient;
 
   constructor(
     paramsOrClient: WebSocketLink.Configuration | SubscriptionClient,


### PR DESCRIPTION
This makes it possible to manually set callbacks for `onDisconnected`, `onReconnected` etc. The advantage here is end users will be able to better handle network blips rather than having apollo have to handle it. See https://github.com/apollographql/apollo-link/issues/234 for an example of folks using this functionality now.

An alternative implementation would look like exposing these callbacks as optional parameters in the constructor. Let me know what you prefer!

<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Make sure all of new logic is covered by tests and passes linting
- [ ] Update CHANGELOG.md with your change

