### PR TITLE
Remove TData generic, fixing GraphQL 15 compile

### DIFF
--- a/packages/apollo-link/CHANGELOG.md
+++ b/packages/apollo-link/CHANGELOG.md
@@ -9,7 +9,8 @@ the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-link/blob
 
 ### 1.2.4
 
-- No changes
+- Added `graphql` 15 to peer and dev dependencies; removed `TData` generic parameter from `FetchResult` to bring it into alignment with GraphQL 15 <br />
+  [@zackdotcomputer](https://github.com/zackdotcomputer) in [#1262](https://github.com/apollographql/apollo-link/pull/1262)
 
 ### 1.2.3
 - Added `graphql` 14 to peer and dev deps; Updated `@types/graphql` to 14  <br/>

--- a/packages/apollo-link/package.json
+++ b/packages/apollo-link/package.json
@@ -40,7 +40,7 @@
     "zen-observable-ts": "file:../zen-observable-ts"
   },
   "peerDependencies": {
-    "graphql": "^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0"
+    "graphql": "^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0 || ^15.0.0"
   },
   "devDependencies": {
     "@types/graphql": "14.2.3",

--- a/packages/apollo-link/package.json
+++ b/packages/apollo-link/package.json
@@ -46,7 +46,7 @@
     "@types/graphql": "14.2.3",
     "@types/jest": "24.9.0",
     "@types/node": "9.6.55",
-    "graphql": "14.5.8",
+    "graphql": "15.0.0",
     "graphql-tag": "2.10.1",
     "jest": "24.9.0",
     "rimraf": "2.7.1",

--- a/packages/apollo-link/src/types.ts
+++ b/packages/apollo-link/src/types.ts
@@ -22,10 +22,9 @@ export interface Operation {
 }
 
 export type FetchResult<
-  TData = { [key: string]: any },
   C = Record<string, any>,
   E = Record<string, any>
-> = ExecutionResult<TData> & {
+> = ExecutionResult & {
   extensions?: E;
   context?: C;
 };


### PR DESCRIPTION
In earlier versions of GraphQL, the ExecutionResult took a generic parameter, which it then typecast its return type as. We were, however, just sending `{ [key: string]: any }` for this parameter in all internal cases.

As of GraphQL 15, that generic parameter has been removed, (see this PR)[https://github.com/graphql/graphql-js/pull/2490/commits], and the return type has been fixed to always be `{ [key: string]: any }`.

Since this is already compatible with our default, this PR removes the generic parameter to bring our typing in line with GraphQL's typing. This is, however, a breaking change for anyone who was depending on this generic parameter to do their typecast for them.

<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Make sure all of new logic is covered by tests and passes linting
- [x] Update CHANGELOG.md with your change

