### PR TITLE
Support GraphQL v15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ### Improvements
 
+- Support GraphQL v15 [PR #1263](https://github.com/apollographql/apollo-link/pull/1263) [#1261](https://github.com/apollographql/apollo-link/issues/1261)
 - Several dependency updates
 - Documentation updates. <br/>
   [@samtheson](https://github.com/samtheson) in [#1130](https://github.com/apollographql/apollo-link/pull/1130)
-
 
 ## 2019-06-14
 

--- a/packages/apollo-link-batch-http/package.json
+++ b/packages/apollo-link-batch-http/package.json
@@ -40,13 +40,13 @@
     "tslib": "^1.9.3"
   },
   "peerDependencies": {
-    "graphql": "^0.11.0 || ^0.12.3 || ^0.13.0 || ^14.0.0"
+    "graphql": "^0.11.0 || ^0.12.3 || ^0.13.0 || ^14.0.0 || ^15.0.0"
   },
   "devDependencies": {
     "@types/graphql": "14.2.3",
     "@types/jest": "24.9.0",
     "fetch-mock": "6.5.2",
-    "graphql": "14.5.8",
+    "graphql": "15.0.0",
     "graphql-tag": "2.10.1",
     "jest": "24.9.0",
     "object-to-querystring": "1.0.8",

--- a/packages/apollo-link-batch/package.json
+++ b/packages/apollo-link-batch/package.json
@@ -41,7 +41,7 @@
     "@types/graphql": "14.2.3",
     "@types/jest": "24.9.0",
     "fetch-mock": "6.5.2",
-    "graphql": "14.5.8",
+    "graphql": "15.0.0",
     "graphql-tag": "2.10.1",
     "jest": "24.9.0",
     "proxyquire": "1.8.0",

--- a/packages/apollo-link-context/package.json
+++ b/packages/apollo-link-context/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@types/graphql": "14.2.3",
     "@types/jest": "24.9.0",
-    "graphql": "14.5.8",
+    "graphql": "15.0.0",
     "graphql-tag": "2.10.1",
     "jest": "24.9.0",
     "rimraf": "2.7.1",

--- a/packages/apollo-link-dedup/package.json
+++ b/packages/apollo-link-dedup/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@types/graphql": "14.2.3",
     "@types/jest": "24.9.0",
-    "graphql": "14.5.8",
+    "graphql": "15.0.0",
     "graphql-tag": "2.10.1",
     "jest": "24.9.0",
     "rimraf": "2.7.1",

--- a/packages/apollo-link-error/package.json
+++ b/packages/apollo-link-error/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@types/graphql": "14.2.3",
     "@types/jest": "24.9.0",
-    "graphql": "14.5.8",
+    "graphql": "15.0.0",
     "graphql-tag": "2.10.1",
     "jest": "24.9.0",
     "rimraf": "2.7.1",

--- a/packages/apollo-link-error/src/index.ts
+++ b/packages/apollo-link-error/src/index.ts
@@ -6,8 +6,9 @@ import {
   Operation,
   NextLink,
   FetchResult,
+  ExecutionResult,
 } from 'apollo-link';
-import { GraphQLError, ExecutionResult } from 'graphql';
+import { GraphQLError } from 'graphql';
 import { ServerError, ServerParseError } from 'apollo-link-http-common';
 
 export interface ErrorResponse {

--- a/packages/apollo-link-http-common/package.json
+++ b/packages/apollo-link-http-common/package.json
@@ -30,13 +30,13 @@
     "tslib": "^1.9.3"
   },
   "peerDependencies": {
-    "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
+    "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
   },
   "devDependencies": {
     "@types/graphql": "14.2.3",
     "@types/jest": "24.9.0",
     "fetch-mock": "6.5.2",
-    "graphql": "14.5.8",
+    "graphql": "15.0.0",
     "graphql-tag": "2.10.1",
     "jest": "24.9.0",
     "object-to-querystring": "1.0.8",

--- a/packages/apollo-link-http/package.json
+++ b/packages/apollo-link-http/package.json
@@ -40,14 +40,14 @@
     "tslib": "^1.9.3"
   },
   "peerDependencies": {
-    "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
+    "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
   },
   "devDependencies": {
     "@types/graphql": "14.2.3",
     "@types/jest": "24.9.0",
     "apollo-fetch": "0.7.0",
     "fetch-mock": "6.5.2",
-    "graphql": "14.5.8",
+    "graphql": "15.0.0",
     "graphql-tag": "2.10.1",
     "jest": "24.9.0",
     "object-to-querystring": "1.0.8",

--- a/packages/apollo-link-polling/package.json
+++ b/packages/apollo-link-polling/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@types/graphql": "14.2.3",
     "@types/jest": "24.9.0",
-    "graphql": "14.5.8",
+    "graphql": "15.0.0",
     "graphql-tag": "2.10.1",
     "jest": "24.9.0",
     "rimraf": "2.7.1",

--- a/packages/apollo-link-retry/package.json
+++ b/packages/apollo-link-retry/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/graphql": "14.2.3",
     "@types/jest": "24.9.0",
-    "graphql": "14.5.8",
+    "graphql": "15.0.0",
     "graphql-tag": "2.10.1",
     "jest": "24.9.0",
     "rimraf": "2.7.1",

--- a/packages/apollo-link-schema/package.json
+++ b/packages/apollo-link-schema/package.json
@@ -40,12 +40,12 @@
     "tslib": "^1.9.3"
   },
   "peerDependencies": {
-    "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
+    "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
   },
   "devDependencies": {
     "@types/graphql": "14.2.3",
     "@types/jest": "24.9.0",
-    "graphql": "14.5.8",
+    "graphql": "15.0.0",
     "graphql-tag": "2.10.1",
     "graphql-tools": "2.24.0",
     "jest": "24.9.0",

--- a/packages/apollo-link-schema/package.json
+++ b/packages/apollo-link-schema/package.json
@@ -47,7 +47,7 @@
     "@types/jest": "24.9.0",
     "graphql": "15.0.0",
     "graphql-tag": "2.10.1",
-    "graphql-tools": "2.24.0",
+    "graphql-tools": "4.0.7",
     "jest": "24.9.0",
     "rimraf": "2.7.1",
     "rollup": "1.29.1",

--- a/packages/apollo-link-schema/src/__tests__/schemaLink.ts
+++ b/packages/apollo-link-schema/src/__tests__/schemaLink.ts
@@ -1,5 +1,4 @@
-import { Observable, ApolloLink, execute } from 'apollo-link';
-import { print, graphql } from 'graphql';
+import { execute } from 'apollo-link';
 import { makeExecutableSchema } from 'graphql-tools';
 import gql from 'graphql-tag';
 

--- a/packages/apollo-link-schema/src/index.ts
+++ b/packages/apollo-link-schema/src/index.ts
@@ -1,6 +1,6 @@
 import { ApolloLink, Operation, FetchResult, Observable } from 'apollo-link';
 import { execute } from 'graphql/execution/execute';
-import { GraphQLSchema } from 'graphql/type/schema';
+import { GraphQLSchema } from 'graphql';
 
 export namespace SchemaLink {
   export type ResolverContextFunction = (

--- a/packages/apollo-link-ws/package.json
+++ b/packages/apollo-link-ws/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@types/graphql": "14.2.3",
     "@types/jest": "24.9.0",
-    "graphql": "14.5.8",
+    "graphql": "15.0.0",
     "graphql-tag": "2.10.1",
     "jest": "24.9.0",
     "rimraf": "2.7.1",

--- a/packages/apollo-link-ws/src/__tests__/webSocketLink.ts
+++ b/packages/apollo-link-ws/src/__tests__/webSocketLink.ts
@@ -1,6 +1,5 @@
 import { SubscriptionClient } from 'subscriptions-transport-ws';
-import { Observable, execute } from 'apollo-link';
-import { ExecutionResult } from 'graphql';
+import { Observable, execute, ExecutionResult } from 'apollo-link';
 
 import { WebSocketLink } from '../webSocketLink';
 

--- a/packages/apollo-link/package.json
+++ b/packages/apollo-link/package.json
@@ -40,13 +40,13 @@
     "zen-observable-ts": "file:../zen-observable-ts"
   },
   "peerDependencies": {
-    "graphql": "^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0"
+    "graphql": "^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0 || ^15.0.0"
   },
   "devDependencies": {
     "@types/graphql": "14.2.3",
     "@types/jest": "24.9.0",
     "@types/node": "9.6.55",
-    "graphql": "14.5.8",
+    "graphql": "15.0.0",
     "graphql-tag": "2.10.1",
     "jest": "24.9.0",
     "rimraf": "2.7.1",

--- a/packages/apollo-link/src/types.ts
+++ b/packages/apollo-link/src/types.ts
@@ -1,7 +1,15 @@
 import Observable from 'zen-observable-ts';
 import { DocumentNode } from 'graphql/language/ast';
-import { ExecutionResult } from 'graphql/execution/execute';
-export { ExecutionResult, DocumentNode };
+import { ExecutionResult as GraphQLExecutionResult } from 'graphql';
+export { DocumentNode };
+
+export interface ExecutionResult<
+  TData = {
+    [key: string]: any;
+  }
+> extends GraphQLExecutionResult {
+  data?: TData | null;
+}
 
 export interface GraphQLRequest {
   query: DocumentNode;


### PR DESCRIPTION
ExecutionResult no longer has generic type so we use our own ExecutionResult extended by original to keep the shape of result backwards compatible