### PR TITLE
Removed Error tye since it blocks the rest from showing up

### DIFF
--- a/packages/apollo-link-error/src/index.ts
+++ b/packages/apollo-link-error/src/index.ts
@@ -13,7 +13,7 @@ import { ServerError, ServerParseError } from 'apollo-link-http-common';
 
 export interface ErrorResponse {
   graphQLErrors?: ReadonlyArray<GraphQLError>;
-  networkError?: Error | ServerError | ServerParseError;
+  networkError?: ServerError | ServerParseError;
   response?: ExecutionResult;
   operation: Operation;
   forward: NextLink;


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

While going over the apollo link example in https://www.apollographql.com/docs/link/links/context/,
```js
  if (networkError && networkError.name ==='ServerError' && networkError.statusCode === 401) {
    // remove cached token on 401 from the server
    token = null;
  }
```
the `statusCode` property wasn't recognized in my editor:
![Screen Shot 2020-05-02 at 12 39 22 AM](https://user-images.githubusercontent.com/9118852/80857123-81edb180-8c1d-11ea-899c-f8178346f03a.png)

I believe since both `ServerError` and `ServerParseError` already include `Error` with `&` operator:
```
export declare type ServerError = Error & {
    response: Response;
    result: Record<string, any>;
    statusCode: number;
};

export declare type ServerParseError = Error & {
    response: Response;
    statusCode: number;
    bodyText: string;
};
```
it should make sense to remove it. The TS lint error disappears and allows me to see the valid contents of the error.

- [x] Make sure all of new logic is covered by tests and passes linting
- [x] Update CHANGELOG.md with your change

