### PR TITLE
Update apollo-utilities to 1.3.4

### DIFF
--- a/packages/apollo-link/package.json
+++ b/packages/apollo-link/package.json
@@ -34,7 +34,7 @@
     "watch": "tsc -w -p . & rollup -c -w"
   },
   "dependencies": {
-    "apollo-utilities": "^1.3.0",
+    "apollo-utilities": "^1.3.4",
     "ts-invariant": "^0.4.0",
     "tslib": "^1.9.3",
     "zen-observable-ts": "file:../zen-observable-ts"


### PR DESCRIPTION
Before 1.3.4, `apollo-utilities` didn't have `graphql@^15.0.0` as a
peer dependency, so when `apollo-link` is already installed and
user switched to `graphql@15.0.0` they could have peer dependency
warnings. This update solves the problem.

<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Make sure all of new logic is covered by tests and passes linting
- [ ] Update CHANGELOG.md with your change

