### PR TITLE
Added commas to standalone example

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -139,10 +139,10 @@ const link = new HttpLink({ uri });
 
 const operation = {
   query: gql`query { hello }`,
-  variables: {} //optional
-  operationName: {} //optional
-  context: {} //optional
-  extensions: {} //optional
+  variables: {}, //optional
+  operationName: {}, //optional
+  context: {}, //optional
+  extensions: {}, //optional
 };
 
 // execute returns an Observable so it can be subscribed to


### PR DESCRIPTION
Standalone example was triggering an error because the object operation had syntax errors. I added commas to fix it

<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Make sure all of new logic is covered by tests and passes linting
- [ ] Update CHANGELOG.md with your change

