### PR TITLE
Expose WS implementation options

### DIFF
--- a/packages/apollo-link-ws/src/webSocketLink.ts
+++ b/packages/apollo-link-ws/src/webSocketLink.ts
@@ -21,6 +21,13 @@ export namespace WebSocketLink {
      * A custom WebSocket implementation to use.
      */
     webSocketImpl?: any;
+    
+    
+    /**
+     * Passed in as the second option of the WebSocket implementation.
+     * On the browser it is wsProtocols but in Node it's implementation specific.
+     */
+    webSocketImplOptions?: any;
   }
 }
 
@@ -42,6 +49,7 @@ export class WebSocketLink extends ApolloLink {
         paramsOrClient.uri,
         paramsOrClient.options,
         paramsOrClient.webSocketImpl,
+        paramsOrClient.webSocketImplOptions,
       );
     }
   }


### PR DESCRIPTION
Hi, the `subscriptions-transport-ws` package has a 4th option:

```js
constructor(
    url: string,
    options?: ClientOptions,
    webSocketImpl?: any,
    webSocketProtocols?: string | string[],
  )
```

Which is called here:

```js
  private connect() {
    this.client = new this.wsImpl(this.url, this.wsProtocols);
```

This is an important option for using Apollo on Node since we typically use the `ws` package where the second parameter to `ws` is a bunch of important options.

One of these options is the ability to pass HTTP headers for example, which are not limited on the server. This makes it a lot simpler to implement secure subscriptions to other micro-services if the Apollo server is a gateway for example:

```js
const wsLink = new ApolloLink((operation) => {
  const context = operation.getContext().graphqlContext

  const headers = {
    'content-type': 'application/json',
    authorization: context.authToken,
  }

  // Create a new websocket link per request
  return new WebSocketLink({
    uri: subscriptionsUri,
    options: {
      reconnect: true,
      connectionParams: {
        headers,
      },
    },
    webSocketImpl: ws,
    webSocketImplOptions: { headers },
  }).request(operation)
})
```

Now we can forward secure subscriptions to other mircro-services much more easily than waiting and parsing a `connection_init` message which contains `connectionParams`.

<!--
  Thanks for filing a pull request on Apollo Link!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Make sure all of new logic is covered by tests and passes linting
- [ ] Update CHANGELOG.md with your change

